### PR TITLE
DeletedAt is a pointer to time.Time

### DIFF
--- a/mongo/document/paranoid.go
+++ b/mongo/document/paranoid.go
@@ -9,15 +9,15 @@ import (
 
 type Paranoid struct {
 	Base      `bson:",inline"`
-	DeletedAt time.Time `bson:"deleted_at,omitempty" json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `bson:"deleted_at,omitempty" json:"deleted_at,omitempty"`
 }
 
 func (p Paranoid) IsDeleted() bool {
-	return !p.DeletedAt.IsZero()
+	return p.DeletedAt != nil
 }
 
 func (d *Paranoid) setDeletedAt(t time.Time) {
-	d.DeletedAt = t
+	d.DeletedAt = &t
 }
 
 func (d Paranoid) scope(query bson.M) bson.M {


### PR DESCRIPTION
Related to Scalingo/autoscaler-service#58

The problem I try to solve here is the following. We set the `DeletedAt` field json tag with `omitempty`. However it can't work as the `time.Time` type is a structure. 

Hence, when marshaling a structure with paranoid:

```go
type Scaler struct {
	DeletedAt time.Time `json:"deleted_at,omitempty"`
	LastScale time.Time `json:"last_scale,omitempty"`
}

func main() {
	s := &Scaler{}
	j, _ := json.Marshal(s)
	fmt.Printf("JSON: %+v\n", string(j))
}
```

we get the following output:

```text
JSON: {"deleted_at":"0001-01-01T00:00:00Z","last_scale":"0001-01-01T00:00:00Z"}
```

But we don't want to send the `DeletedAt` field if it has a zero value. Defining it as a pointer of `time.Time` fixes this issue.