### PR TITLE
GoMock generator CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+gomock_generator/gomock_generator

--- a/gomock_generator/README.md
+++ b/gomock_generator/README.md
@@ -13,7 +13,7 @@ NAME:
    GoMock generator - Highly parallelized generator of gomock mocks
 
 USAGE:
-   gomock_generator [global options] command [command options] [arguments...]
+   gomock_generator [global options]
 
 VERSION:
    0.1.0

--- a/gomock_generator/README.md
+++ b/gomock_generator/README.md
@@ -1,0 +1,38 @@
+# GoMock Generator
+
+This tool aims at simplifying and accelerating the generation of mocks in Scalingo projects using
+[GoMock](https://github.com/golang/mock/).
+
+This tool can either be used as a CLI or as a Go library.
+
+## CLI
+
+```text
+$ gomock_generator -h
+NAME:
+   GoMock generator - Highly parallelized generator of gomock mocks
+
+USAGE:
+   gomock_generator [global options] command [command options] [arguments...]
+
+VERSION:
+   0.1.0
+
+COMMANDS:
+     help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --base-package value           Project base package. E.g. github.com/Scalingo/go-utils. [$BASE_PACKAGE]
+   --mocks-filename value         Filename of the JSON file containing the MockConfiguration. Location of this file is the base package. (default: "mocks.json") [$MOCKS_FILENAME]
+   --signatures-filename value    Filename of the signatures cache. Location of this file is the base package. (default: "mocks_sig.json") [$SIGNATURES_FILENAME]
+   --concurrent-goroutines value  Concurrent amount of goroutines to generate mock. (default: 4) [$CONCURRENT_GOROUTINES]
+   --debug                        Activate debug logs
+   --help, -h                     show help
+   --version, -v                  print the version
+```
+
+## Go Library
+
+The `gomockgenerator` package provides a `GenerateMocks` function. It works along with the
+`GenerationConfiguration` and `MocksConfiguration` structures. Comments in the code explain the
+purpose of every attribute.

--- a/gomock_generator/gomockgenerator/generate.go
+++ b/gomock_generator/gomockgenerator/generate.go
@@ -1,0 +1,215 @@
+package gomockgenerator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/Scalingo/go-utils/logger"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// GenerationConfiguration lets you configure the generation of mocks for your project
+type GenerationConfiguration struct {
+	// MocksFilename is the filename of the JSON file containing the mock configuration.  Location of this file is the base package.
+	MocksFilename string
+	// SignaturesFilename is the filename of the signatures cache. Location of this file is the base package.
+	SignaturesFilename string
+	// ConcurrentGoroutines specifies the concurrent amount of goroutines which can execute
+	ConcurrentGoroutines int
+}
+
+// MocksConfiguration contains the configuration of the mocks to generate.
+type MocksConfiguration struct {
+	// BasePackage is the project base package. E.g. github.com/Scalingo/go-utils
+	BasePackage string `json:"base_package"`
+	// Mocks contains the configuration of all the mocks to generate
+	Mocks []MockConfiguration `json:"mocks"`
+}
+
+// MockConfiguration represents a mock and how to generate it.
+type MockConfiguration struct {
+	// Interface is the name of the interface we need to generate a mock for.
+	Interface string `json:"interface"`
+	// Mockfile is the location of the generated mock file. Relative path from the root of the
+	// project. Defaults to a subfolder of SrcPackage ending with "mock".
+	MockFile string `json:"mock_file,omitempty"`
+	// SrcPackage is the complete name of the source package. E.g. "model/backup". Defaults to the
+	// directory part of Mockfile.
+	SrcPackage string `json:"src_package,omitempty"`
+	// DstPackage: name of the package of Mockfile. Defaults to the name of the folder of Mockfile.
+	DstPackage string `json:"dst_package,omitempty"`
+	// External specifies if the generated mock is about a package external to the project.
+	External bool `json:"external,omitempty"`
+}
+
+// GenerateMocks generates the mocks given in arguments
+func GenerateMocks(ctx context.Context, gcfg GenerationConfiguration, mocksCfg MocksConfiguration) error {
+	if mocksCfg.BasePackage == "" {
+		panic(errors.New("BasePackage is mandatory"))
+	}
+	log := logger.Get(ctx).WithField("nb_mocks", len(mocksCfg.Mocks))
+	ctx = logger.ToCtx(ctx, log)
+	log.WithFields(logrus.Fields{
+		"base_package": mocksCfg.BasePackage,
+	}).Infof("Generating %v mocks", len(mocksCfg.Mocks))
+
+	var mockSigs map[string]string
+	mockSigsPath := path.Join(os.Getenv("GOPATH"), "src", mocksCfg.BasePackage, gcfg.SignaturesFilename)
+
+	sigs, err := ioutil.ReadFile(mockSigsPath)
+	if os.IsNotExist(err) {
+		log.Info("No cache signatures file, generates all mocks")
+	} else if err != nil {
+		return errors.Wrap(err, "fail to read the signatures cache file")
+	} else {
+		err = json.Unmarshal(sigs, &mockSigs)
+		if err != nil {
+			return errors.Wrap(err, "fail to unmarshal the signatures cache file")
+		}
+	}
+	newMockSigs := make(map[string]string, len(sigs))
+	lock := sync.Mutex{}
+
+	var wg sync.WaitGroup
+	sem := make(chan bool, gcfg.ConcurrentGoroutines)
+	for _, mock := range mocksCfg.Mocks {
+		wg.Add(1)
+		go func(mock MockConfiguration) {
+			sem <- true
+			path, sig, err := generateMock(ctx, mocksCfg.BasePackage, mock, mockSigs)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			lock.Lock()
+			newMockSigs[path] = sig
+			lock.Unlock()
+			<-sem
+			wg.Done()
+		}(mock)
+	}
+	wg.Wait()
+
+	sigs, err = json.Marshal(newMockSigs)
+	if err != nil {
+		return errors.Wrap(err, "fail to marshal the signatures cache file")
+	}
+	err = ioutil.WriteFile(mockSigsPath, sigs, 0644)
+	if err != nil {
+		return errors.Wrap(err, "fail to write the signatures cache file")
+	}
+	return nil
+}
+
+func generateMock(ctx context.Context, basePackage string, mock MockConfiguration, sigs map[string]string) (string, string, error) {
+	log := logger.Get(ctx)
+	if mock.MockFile == "" {
+		mock.MockFile = path.Join(
+			mock.SrcPackage,
+			fmt.Sprintf("%smock", filepath.Base(mock.SrcPackage)),
+			fmt.Sprintf("%s_mock.go", strings.ToLower(mock.Interface)),
+		)
+	}
+
+	if mock.DstPackage == "" {
+		dst := filepath.Base(filepath.Dir(mock.MockFile))
+		mock.DstPackage = dst
+	}
+
+	if mock.SrcPackage == "" {
+		mock.SrcPackage = filepath.Dir(mock.MockFile)
+	}
+
+	if !mock.External {
+		mock.SrcPackage = path.Join(basePackage, mock.SrcPackage)
+	}
+
+	mockPath := filepath.Join(os.Getenv("GOPATH"), "src", basePackage, mock.MockFile)
+	log = log.WithFields(logrus.Fields{
+		"mock_file":   mock.MockFile,
+		"interface":   mock.Interface,
+		"dst_package": mock.DstPackage,
+	})
+	ctx = logger.ToCtx(ctx, log)
+	log.Info("Generating a mock")
+	log.WithFields(logrus.Fields{
+		"mock_path":   mockPath,
+		"src_package": mock.SrcPackage,
+	}).Debug("Mock configuration")
+
+	dir := filepath.Dir(mockPath)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		log.Fatal("fail to create directory", dir, ":", err)
+	}
+
+	selfPackage := ""
+	if filepath.Dir(mock.MockFile) == mock.SrcPackage {
+		log = log.WithField("self_package", true)
+		ctx = logger.ToCtx(ctx, log)
+		selfPackage = "-self_package " + path.Join(basePackage, mock.SrcPackage)
+	}
+
+	hashKey := fmt.Sprintf("%s.%s", mock.SrcPackage, mock.Interface)
+	hash, err := interfaceHash(mock.SrcPackage, mock.Interface)
+	if err != nil {
+		return "", "", errors.Wrap(err, "fail to get interface hash")
+	}
+	if _, err := os.Stat(mockPath); os.IsNotExist(err) {
+		hash = "NOFILE"
+	}
+
+	if sigs[hashKey] == hash {
+		log.Info("Skipping!")
+		return hashKey, hash, nil
+	}
+
+	log.WithFields(logrus.Fields{
+		"hashkey":  hashKey,
+		"expected": sigs[hashKey],
+		"current":  hash,
+	}).Info("Signature is not matching, regenerating")
+
+	vendorDir := path.Join(basePackage, "vendor")
+	cmd := fmt.Sprintf(
+		"mockgen -destination %s %s -package %s %s %s && sed -i s,%s,, %s && goimports -w %s",
+		mockPath, selfPackage, mock.DstPackage, mock.SrcPackage, mock.Interface,
+		vendorDir, mockPath, mockPath,
+	)
+	g := exec.Command("sh", "-c", cmd)
+	log.WithField("cmd", cmd).Debug("Execute mockgen command")
+
+	stdout, err := g.StdoutPipe()
+	if err != nil {
+		return "", "", errors.Wrap(err, "fail to get stdout")
+	}
+	stderr, err := g.StderrPipe()
+	if err != nil {
+		return "", "", errors.Wrap(err, "fail to get stderr")
+	}
+	go io.Copy(os.Stdout, stdout)
+	go io.Copy(os.Stderr, stderr)
+
+	err = g.Start()
+	if err != nil {
+		return "", "", errors.Wrap(err, "fail to start")
+	}
+
+	err = g.Wait()
+	if err != nil {
+		return "", "", errors.Wrap(err, "fail to wait")
+	}
+
+	log.Info("Done!")
+	return hashKey, hash, nil
+}

--- a/gomock_generator/gomockgenerator/package.go
+++ b/gomock_generator/gomockgenerator/package.go
@@ -1,0 +1,104 @@
+package gomockgenerator
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func interfaceHash(pkg, iName string) (string, error) {
+	sig, err := interfaceSignature(pkg, iName)
+	if err != nil {
+		return "", errors.Wrapf(err, "fail to get interface signature for %s", iName)
+	}
+	hash := sha1.Sum([]byte(sig))
+	return fmt.Sprintf("% x", hash), nil
+}
+
+func interfaceSignature(pkg, iName string) (string, error) {
+	fullPath := path.Join(os.Getenv("GOPATH"), "src", pkg)
+	fileSet := token.NewFileSet()
+	packages, err := parser.ParseDir(fileSet, fullPath, func(info os.FileInfo) bool {
+		return !strings.HasSuffix(info.Name(), "_test.go")
+	}, 0)
+
+	if err != nil {
+		return "", errors.Wrap(err, "fail to parse package")
+	}
+
+	if len(packages) != 1 {
+		for name := range packages {
+			fmt.Println(name)
+		}
+		return "", errors.New("too many packages")
+	}
+
+	for _, pck := range packages {
+		for _, f := range pck.Files {
+			for _, decl := range f.Decls {
+				if gen, ok := decl.(*ast.GenDecl); ok {
+					if gen.Tok == token.TYPE {
+						for _, spec := range gen.Specs {
+							if typeSpec, ok := spec.(*ast.TypeSpec); ok {
+								if interfaceType, ok := typeSpec.Type.(*ast.InterfaceType); ok {
+									if typeSpec.Name.String() == iName {
+										var interfaceSig string
+										for _, m := range interfaceType.Methods.List {
+											methodName := m.Names[0].String()
+											funcType := m.Type.(*ast.FuncType)
+											var methodType string
+
+											if funcType.Results != nil {
+												for _, res := range funcType.Results.List {
+													methodType = fmt.Sprintf("%s,%s", methodType, fieldToString(res.Type))
+												}
+											}
+
+											var methodParams string
+											if funcType.Params != nil {
+												for _, param := range funcType.Params.List {
+													methodParams = fmt.Sprintf("%s,%s", methodParams, fieldToString(param.Type))
+												}
+											}
+											interfaceSig = fmt.Sprintf("%s\n%s(%s)(%s)\n", interfaceSig, methodName, methodParams, methodType)
+										}
+										return interfaceSig, nil
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return "", errors.New("not found")
+}
+
+func fieldToString(field ast.Expr) string {
+	if starExpr, ok := field.(*ast.StarExpr); ok {
+		return "*" + fieldToString(starExpr.X)
+	}
+
+	if mapExpr, ok := field.(*ast.MapType); ok {
+		return fmt.Sprintf("map[%s]%s", fieldToString(mapExpr.Key), fieldToString(mapExpr.Value))
+	}
+
+	if arrayExpr, ok := field.(*ast.ArrayType); ok {
+		return fmt.Sprintf("[]%v", fieldToString(arrayExpr.Elt))
+	}
+
+	if _, ok := field.(*ast.InterfaceType); ok {
+		// TODO: It's the only case I can think of, but they might be others.
+		return "interface{}"
+	}
+
+	return fmt.Sprintf("%v", field)
+}

--- a/gomock_generator/main.go
+++ b/gomock_generator/main.go
@@ -44,6 +44,26 @@ Reads the mymocks.json file from the current directory and generates the mocks, 
 		cli.IntFlag{Name: "concurrent-goroutines", Value: 4, Usage: "Concurrent amount of goroutines to generate mock.", EnvVar: "CONCURRENT_GOROUTINES"},
 		cli.BoolFlag{Name: "debug", Usage: "Activate debug logs"},
 	}
+	cli.AppHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+USAGE:
+   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}
+   {{if len .Authors}}
+AUTHOR:
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
+COMMANDS:
+{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+GLOBAL OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}{{if .Copyright }}
+COPYRIGHT:
+   {{.Copyright}}
+   {{end}}{{if .Version}}
+VERSION:
+   {{.Version}}
+   {{end}}
+`
 	app.cli.Before = func(c *cli.Context) error {
 		app.config.MocksFilename = c.GlobalString("mocks-filename")
 		app.config.SignaturesFilename = c.GlobalString("signatures-filename")

--- a/gomock_generator/main.go
+++ b/gomock_generator/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Scalingo/go-utils/gomock_generator/gomockgenerator"
+	"github.com/Scalingo/go-utils/logger"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+type app struct {
+	config gomockgenerator.GenerationConfiguration
+	cli    *cli.App
+}
+
+func main() {
+	log := logger.Default()
+	ctx := logger.ToCtx(context.Background(), log)
+
+	cli.AppHelpTemplate = fmt.Sprintf(`%s
+EXAMPLE:
+
+%s --concurrent-goroutine 8 --mocks-filename mymocks.json --signatures-filename sigs.json
+
+Reads the mymocks.json file from the current directory and generates the mocks, 8 goroutines at a time. The signatures of the mocks are stored in sigs.json, in the folder designated by the base package written in mymocks.json.
+
+`, cli.AppHelpTemplate, os.Args[0])
+
+	app := app{
+		config: gomockgenerator.GenerationConfiguration{},
+		cli:    cli.NewApp(),
+	}
+	app.cli.Name = "GoMock generator"
+	app.cli.Usage = "Highly parallelized generator of gomock mocks"
+	app.cli.Version = "0.1.0"
+	app.cli.Flags = []cli.Flag{
+		cli.StringFlag{Name: "mocks-filename", Value: "mocks.json", Usage: "Filename of the JSON file containing the MockConfiguration. Location of this file is the base package.", EnvVar: "MOCKS_FILENAME"},
+		cli.StringFlag{Name: "signatures-filename", Value: "mocks_sig.json", Usage: "Filename of the signatures cache. Location of this file is the base package.", EnvVar: "SIGNATURES_FILENAME"},
+		cli.IntFlag{Name: "concurrent-goroutines", Value: 4, Usage: "Concurrent amount of goroutines to generate mock.", EnvVar: "CONCURRENT_GOROUTINES"},
+		cli.BoolFlag{Name: "debug", Usage: "Activate debug logs"},
+	}
+	app.cli.Before = func(c *cli.Context) error {
+		app.config.MocksFilename = c.GlobalString("mocks-filename")
+		app.config.SignaturesFilename = c.GlobalString("signatures-filename")
+		app.config.ConcurrentGoroutines = c.GlobalInt("concurrent-goroutines")
+		if c.GlobalBool("debug") {
+			log.SetLevel(logrus.DebugLevel)
+			logger.ToCtx(ctx, log)
+		}
+		return nil
+	}
+	app.cli.Action = func(_ctx *cli.Context) error {
+		log.WithFields(logrus.Fields{
+			"mocks_filename":        app.config.MocksFilename,
+			"signatures_filename":   app.config.SignaturesFilename,
+			"concurrent_goroutines": app.config.ConcurrentGoroutines,
+		}).Info("Configuration for this mocks generation")
+
+		rawFile, err := os.Open(app.config.MocksFilename)
+		if err != nil {
+			return errors.Wrap(err, "fail to open the mocks file")
+		}
+		defer rawFile.Close()
+
+		mocksConfiguration := gomockgenerator.MocksConfiguration{}
+		err = json.NewDecoder(rawFile).Decode(&mocksConfiguration)
+		if err != nil {
+			return errors.Wrap(err, "mocks file does not contain valid JSON")
+		}
+
+		return gomockgenerator.GenerateMocks(ctx, app.config, mocksConfiguration)
+	}
+
+	err := app.cli.Run(os.Args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
```text
$ gomock_generator -h                                                  
NAME:
   Gomock generator - Highly parallelized generator of gomock mocks

USAGE:
   gomock_generator [global options] command [command options] [arguments...]

VERSION:
   0.1.0

COMMANDS:
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --base-package value           Project base package. E.g. github.com/Scalingo/go-utils. [$BASE_PACKAGE]
   --mocks-filename value         Filename of the JSON file containing the MockConfiguration. Location of this file is the base package. (default: "mocks.json") [$MOCKS_FILENAME]
   --signatures-filename value    Filename of the signatures cache. Location of this file is the base package. (default: "mocks_sig.json") [$SIGNATURES_FILENAME]
   --concurrent-goroutines value  Concurrent amount of goroutines to generate mock. (default: 4) [$CONCURRENT_GOROUTINES]
   --debug                        Activate debug logs
   --help, -h                     show help
   --version, -v                  print the version
```

Fix #61