### PR TITLE
Measurement must be between double quotes to prevent issues with measurement name which contains character such as dash

### DIFF
--- a/influx/querybuilder.go
+++ b/influx/querybuilder.go
@@ -70,7 +70,7 @@ func String(param string) string {
 // On sets the measurement of the current query. Calling it twice will take the latest measurement
 // provided.
 func (q Query) On(measurement string) Query {
-	q.measurement = measurement
+	q.measurement = fmt.Sprintf("\"%s\"", measurement)
 	return q
 }
 

--- a/influx/querybuilder_test.go
+++ b/influx/querybuilder_test.go
@@ -56,43 +56,43 @@ func TestQueryBuilder(t *testing.T) {
 		{
 			Name:     "a basic query",
 			Query:    NewQuery().On("serie").Field("test", "mean"),
-			Expected: `SELECT mean("test") AS "test" FROM serie`,
+			Expected: `SELECT mean("test") AS "test" FROM "serie"`,
 		}, {
 			Name:     "with a basic condition",
 			Query:    NewQuery().On("serie").Field("test", "mean").Where("condF", Equal, `"value"`),
-			Expected: `SELECT mean("test") AS "test" FROM serie WHERE condF = "value"`,
+			Expected: `SELECT mean("test") AS "test" FROM "serie" WHERE condF = "value"`,
 		}, {
 			Name:     "with a complex condition",
 			Query:    NewQuery().On("serie").Field("test", "mean").Where("cond1F", Equal, `"value"`).And("cond2F", MoreOrEqual, "time() - 3m"),
-			Expected: `SELECT mean("test") AS "test" FROM serie WHERE cond1F = "value" AND cond2F >= time() - 3m`,
+			Expected: `SELECT mean("test") AS "test" FROM "serie" WHERE cond1F = "value" AND cond2F >= time() - 3m`,
 		}, {
 			Name:     "with an even more complex condition",
 			Query:    NewQuery().On("serie").Field("test", "mean").Where("cond1F", Equal, `"value"`).And("cond2F", MoreOrEqual, "time() - 3m").And("cond3F", Equal, "'app_id'"),
-			Expected: `SELECT mean("test") AS "test" FROM serie WHERE cond1F = "value" AND cond2F >= time() - 3m AND cond3F = 'app_id'`,
+			Expected: `SELECT mean("test") AS "test" FROM "serie" WHERE cond1F = "value" AND cond2F >= time() - 3m AND cond3F = 'app_id'`,
 		}, {
 			Name:     "with a group by tag",
 			Query:    NewQuery().On("serie").Field("f1", "last").GroupByTag("tag1"),
-			Expected: `SELECT last("f1") AS "f1" FROM serie GROUP BY tag1`,
+			Expected: `SELECT last("f1") AS "f1" FROM "serie" GROUP BY tag1`,
 		}, {
 			Name:     "with multiple group by time",
 			Query:    NewQuery().On("serie").Field("f1", "last").GroupByTag("tag1").GroupByTag("tag2"),
-			Expected: `SELECT last("f1") AS "f1" FROM serie GROUP BY tag1,tag2`,
+			Expected: `SELECT last("f1") AS "f1" FROM "serie" GROUP BY tag1,tag2`,
 		}, {
 			Name:     "with a group by time",
 			Query:    NewQuery().On("serie").Field("f1", "last").GroupByTime(10 * time.Minute),
-			Expected: `SELECT last("f1") AS "f1" FROM serie GROUP BY time(10m0s)`,
+			Expected: `SELECT last("f1") AS "f1" FROM "serie" GROUP BY time(10m0s)`,
 		}, {
 			Name:     "with time, tags and fill",
 			Query:    NewQuery().On("serie").Field("f1", "last").GroupByTag("tag1").GroupByTag("tag2").GroupByTime(1 * time.Second).Fill(Previous),
-			Expected: `SELECT last("f1") AS "f1" FROM serie GROUP BY time(1s),tag1,tag2 fill(previous)`,
+			Expected: `SELECT last("f1") AS "f1" FROM "serie" GROUP BY time(1s),tag1,tag2 fill(previous)`,
 		}, {
 			Name:     "with an order by",
 			Query:    NewQuery().On("serie").Field("f1", "mean").OrderByTime("DESC"),
-			Expected: `SELECT mean("f1") AS "f1" FROM serie ORDER BY time DESC`,
+			Expected: `SELECT mean("f1") AS "f1" FROM "serie" ORDER BY time DESC`,
 		}, {
 			Name:     "with a limit",
 			Query:    NewQuery().On("serie").Field("f1", "mean").Limit(1),
-			Expected: `SELECT mean("f1") AS "f1" FROM serie LIMIT 1`,
+			Expected: `SELECT mean("f1") AS "f1" FROM "serie" LIMIT 1`,
 		},
 	}
 	for _, example := range examples {


### PR DESCRIPTION
Related to Scalingo/metrics-storage-service#66