### PR TITLE
Fix: document Create/Save failed on arm due to serialization errors on arm64

### DIFF
--- a/mongo/document/document.go
+++ b/mongo/document/document.go
@@ -66,7 +66,7 @@ func Create(ctx context.Context, collectionName string, doc document) error {
 	c := mongo.Session(log).Clone().DB("").C(collectionName)
 	defer c.Database.Session.Close()
 	log.WithField(collectionName, doc).Debugf("save '%v'", collectionName)
-	return c.Insert(&doc)
+	return c.Insert(doc)
 
 }
 
@@ -83,7 +83,7 @@ func Save(ctx context.Context, collectionName string, doc document) error {
 	c := mongo.Session(log).Clone().DB("").C(collectionName)
 	defer c.Database.Session.Close()
 	log.WithField(collectionName, doc).Debugf("save '%v'", collectionName)
-	_, err := c.UpsertId(doc.getID(), &doc)
+	_, err := c.UpsertId(doc.getID(), doc)
 	return err
 }
 


### PR DESCRIPTION
Those values are already pointers, we should not take the pointer value instead, i have no idea why this works on amd64/i386