### PR TITLE
Buffer size of 512MB is not a good idea, it was supposed to be 512kB

### DIFF
--- a/tarball/archive.go
+++ b/tarball/archive.go
@@ -40,7 +40,7 @@ func Create(ctx context.Context, src string, dst io.Writer, opts CreateOpts) err
 	}
 	if opts.CopyBufferSize == 0 {
 		// 512kB of read buffer when reading file (instead of 32kB default)
-		opts.CopyBufferSize = 512 * 1024 * 1024
+		opts.CopyBufferSize = 512 * 1024
 	}
 
 	copierOpts := []iopkg.CopierOpt{
@@ -117,7 +117,7 @@ func Extract(ctx context.Context, dst string, reader io.Reader, opts *ExtractOpt
 
 	if opts.CopyBufferSize == 0 {
 		// 512kB of read buffer when reading file (instead of 32kB default)
-		opts.CopyBufferSize = 512 * 1024 * 1024
+		opts.CopyBufferSize = 512 * 1024
 	}
 	copierOpts := []iopkg.CopierOpt{
 		iopkg.WithBufferSize(opts.CopyBufferSize),


### PR DESCRIPTION
It had quite a lot of impact in tar operations in production with large tarball