### PR TITLE
[storage] Authenticate the connection to Swift

### DIFF
--- a/storage/swift.go
+++ b/storage/swift.go
@@ -37,6 +37,11 @@ func NewSwift(cfg SwiftConfig) (*Swift, error) {
 		return nil, errors.Wrapf(err, "fail to get Swift configuration from the environment")
 	}
 
+	err = conn.Authenticate()
+	if err != nil {
+		return nil, errors.Wrapf(err, "fail to authentication to Swift")
+	}
+
 	return &Swift{cfg: cfg, conn: conn}, nil
 }
 


### PR DESCRIPTION
I think this is an issue with github.com/ncw/swift. I may open an issue there to clarify with them. The [documentation](https://pkg.go.dev/github.com/ncw/swift?tab=doc#Connection.Authenticate) about the `Authenticate` method states:

>  If you don't call it before calling one of the connection methods then it will be called for you on the first access. 

Hence, I assumed it's not necessary on our side to call the `Authenticate` method. But when we do that, there is a nil pointer exception:

```
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.(*Connection).storage(0xc0005be540, 0xc00003c1c4, 0x14, 0xc00044a2a0, 0x5b, 0xf54736, 0x4, 0x0, 0x0, 0xc00033c840, ...)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/swift.go:816 +0x7d
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.(*Connection).objectBase(0xc0005be540, 0xc00003c1c4, 0x14, 0xc00044a2a0, 0x5b, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/swift.go:2089 +0xf6
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.(*Connection).Object.func1(0x37e11d600, 0xc00050a190, 0xc000049000, 0xc000417040)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/swift.go:2078 +0xa9
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.withLORetry(0x0, 0xc0005f7110, 0x0, 0x0)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/largeobjects.go:285 +0xa3
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.(*Connection).Object(0xc0005be540, 0xc00003c1c4, 0x14, 0xc00044a2a0, 0x5b, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/swift.go:2077 +0xfc
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.(*Connection).largeObjectCreate(0xc0005be540, 0xc0005f7470, 0xc0, 0x11e, 0x5b)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/largeobjects.go:138 +0x92
github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift.(*Connection).DynamicLargeObjectCreateFile(0xc0005be540, 0xc0005f7470, 0x5b, 0xc0003768c0, 0x133, 0x0)
	/opt/go/services/appsdeck-run/src/github.com/Scalingo/appsdeck-run/vendor/github.com/ncw/swift/dlo.go:18 +0x39
```

We add in this PR the call to `Authenticate` in the constructor of the Swift instance. In this package, we only want authenticated connections anyway.

I tested it in this PR https://github.com/Scalingo/appsdeck-run/pull/90

Related to https://github.com/Scalingo/appsdeck-run/issues/86