### PR TITLE
Take vendor dir into account when generating mocks

### DIFF
--- a/gomock_generator/gomockgenerator/package.go
+++ b/gomock_generator/gomockgenerator/package.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -23,7 +24,14 @@ func interfaceHash(pkg, iName string) (string, error) {
 }
 
 func interfaceSignature(pkg, iName string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", errors.Wrap(err, "fail to get current working directory")
+	}
 	fullPath := path.Join(os.Getenv("GOPATH"), "src", pkg)
+	if _, err := os.Stat(filepath.Join(cwd, "vendor", pkg)); err == nil {
+		fullPath = filepath.Join(cwd, "vendor", pkg)
+	}
 	fileSet := token.NewFileSet()
 	packages, err := parser.ParseDir(fileSet, fullPath, func(info os.FileInfo) bool {
 		return !strings.HasSuffix(info.Name(), "_test.go")


### PR DESCRIPTION
Before:
```
└> gomock_generator
INFO[2020-08-17T15:32:41.525] Configuration for this mocks generation       concurrent_goroutines=4 mocks_file_path=./mocks.json signatures_filename=mocks_sig.json
INFO[2020-08-17T15:32:41.526] Generating 129 mocks                          base_package=github.com/Scalingo/appsdeck-database nb_mocks=129
ERRO[2020-08-17T15:32:41.587] fail to get interface hash: fail to get interface signature for Client: fail to parse package: open /home/leo/go/src/github.com/influxdata/influxdb/client/v2: no such file or directory  nb_mocks=129
```

After:
```
└> gomock_generator
INFO[2020-08-17T15:44:49.631] Configuration for this mocks generation       concurrent_goroutines=4 mocks_file_path=./mocks.json signatures_filename=mocks_sig.json
INFO[2020-08-17T15:44:49.632] Generating 129 mocks                          base_package=github.com/Scalingo/appsdeck-database nb_mocks=129
```