### PR TITLE
Validate that goimports and mockgen executables are presents, otherwise installing them

### DIFF
--- a/gomock_generator/main.go
+++ b/gomock_generator/main.go
@@ -134,7 +134,20 @@ func validateBinaryDeps() error {
 			cmd := exec.Command("go", "get", binary.Package)
 			err = cmd.Run()
 			if err != nil {
-				return errors.Wrapf(err, "Fail to run 'go get %v'", binary.Package)
+				output, outputErr := cmd.CombinedOutput()
+				if outputErr != nil {
+					return errors.Wrapf(
+						err,
+						"Fail to run 'go get %v', fail to get command output, error: \n\n%v\n",
+						binary.Package, outputErr,
+					)
+				} else {
+					return errors.Wrapf(
+						err,
+						"Fail to run 'go get %v', output: \n\n%v\n",
+						binary.Package, string(output),
+					)
+				}
 			}
 			_, err = exec.LookPath(binary.Executable)
 			if err != nil {

--- a/gomock_generator/main.go
+++ b/gomock_generator/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/Scalingo/go-utils/gomock_generator/gomockgenerator"
 	"github.com/Scalingo/go-utils/logger"
@@ -68,6 +69,11 @@ VERSION:
 		return nil
 	}
 	app.cli.Action = func(c *cli.Context) error {
+		err := validateBinaryDeps()
+		if err != nil {
+			return err
+		}
+
 		log := logger.Default()
 		if c.GlobalBool("debug") {
 			log = logger.Default(logger.WithLogLevel(logrus.DebugLevel))
@@ -100,4 +106,45 @@ VERSION:
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func validateBinaryDeps() error {
+	binaries := []struct {
+		Executable string
+		Package    string
+	}{
+		{
+			Executable: "goimports",
+			Package:    "golang.org/x/tools/cmd/goimports",
+		},
+		{
+			Executable: "mockgen",
+			Package:    "github.com/golang/mock/mockgen",
+		},
+	}
+	for _, binary := range binaries {
+		_, err := exec.LookPath(binary.Executable)
+		if err != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"Executable '%s' not found. Not in $PATH or not installed. Attempt to install.\n\nRunning 'go get %v'...\n\n",
+				binary.Executable,
+				binary.Package,
+			)
+			cmd := exec.Command("go", "get", binary.Package)
+			err = cmd.Run()
+			if err != nil {
+				return errors.Wrapf(err, "Fail to run 'go get %v'", binary.Package)
+			}
+			_, err = exec.LookPath(binary.Executable)
+			if err != nil {
+				return errors.Wrapf(
+					err,
+					"fail to find '%s' binary after installation, $GOPATH/bin probably not in path, update your shell (bash/zsh) configuration",
+					binary.Executable,
+				)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/Scalingo/go-utils/issues/117