### PR TITLE
Allow empty SrcPackage for a mock

### DIFF
--- a/gomock_generator/gomockgenerator/generate.go
+++ b/gomock_generator/gomockgenerator/generate.go
@@ -124,10 +124,17 @@ func GenerateMocks(ctx context.Context, gcfg GenerationConfiguration, mocksCfg M
 
 func generateMock(ctx context.Context, basePackage string, mock MockConfiguration, sigs map[string]string) (string, string, error) {
 	log := logger.Get(ctx)
+
 	if mock.MockFile == "" {
+		basepath := filepath.Base(mock.SrcPackage)
+		// If srcPackage is empty, its Base is "."
+		if basepath == "." {
+			basepath = filepath.Base(basePackage)
+		}
+
 		mock.MockFile = path.Join(
 			mock.SrcPackage,
-			fmt.Sprintf("%smock", filepath.Base(mock.SrcPackage)),
+			fmt.Sprintf("%smock", basepath),
 			fmt.Sprintf("%s_mock.go", strings.ToLower(mock.Interface)),
 		)
 	}
@@ -135,10 +142,6 @@ func generateMock(ctx context.Context, basePackage string, mock MockConfiguratio
 	if mock.DstPackage == "" {
 		dst := filepath.Base(filepath.Dir(mock.MockFile))
 		mock.DstPackage = dst
-	}
-
-	if mock.SrcPackage == "" {
-		mock.SrcPackage = filepath.Dir(mock.MockFile)
 	}
 
 	if !mock.External {


### PR DESCRIPTION
The following situation wasn't working, it is now working as expected.

Director $GOPATH/src/github.com/Scalingo/package

```
/mocks.json
/client.go
```

```json
{
	"package": "github.com/Scalingo/package",
	"mocks": [
		{
			"Interface": "Client"

		}
	]
}
```

Result after gomock_generator:

```
/mocks.json
/mocks_sig.json
/client.go
/packagemock/client_mock.go
```