### PR TITLE
fix(mongo): Display the mongodb object id in the correct format on the logs

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* Display the mongodb object id in the correct format on the logs [#187](https://github.com/Scalingo/go-utils/pull/187)
 * Bump github.com/sirupsen/logrus from 1.7.0 to 1.8.0
 
 ## v1.1.0

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## To be Released
 
-* Display the mongodb object id in the correct format on the logs [#187](https://github.com/Scalingo/go-utils/pull/187)
-* Bump github.com/sirupsen/logrus from 1.7.0 to 1.8.0
+* Display the MongoDB object ID in the correct format on the logs [#187](https://github.com/Scalingo/go-utils/pull/187)
+* Bump github.com/sirupsen/logrus from 1.7.0 to 1.8.1
 
 ## v1.1.0
 

--- a/mongo/document/document.go
+++ b/mongo/document/document.go
@@ -67,7 +67,7 @@ func Create(ctx context.Context, collectionName string, doc document) error {
 	defer c.Database.Session.Close()
 	log.WithFields(logrus.Fields{
 		"collection": collectionName,
-		"doc_id":     doc.getID(),
+		"doc_id":     doc.getID().Hex(),
 	}).Debugf("save '%v'", collectionName)
 	return c.Insert(doc)
 
@@ -87,7 +87,7 @@ func Save(ctx context.Context, collectionName string, doc document) error {
 	defer c.Database.Session.Close()
 	log.WithFields(logrus.Fields{
 		"collection": collectionName,
-		"doc_id":     doc.getID(),
+		"doc_id":     doc.getID().Hex(),
 	}).Debugf("save '%v'", collectionName)
 	_, err := c.UpsertId(doc.getID(), doc)
 	return err
@@ -104,7 +104,7 @@ func ReallyDestroy(ctx context.Context, collectionName string, doc document) err
 	defer c.Database.Session.Close()
 	log.WithFields(logrus.Fields{
 		"collection": collectionName,
-		"doc_id":     doc.getID(),
+		"doc_id":     doc.getID().Hex(),
 	}).Debugf("remove '%v'", collectionName)
 	return c.RemoveId(doc.getID())
 }
@@ -243,7 +243,7 @@ func Update(ctx context.Context, collectionName string, update bson.M, doc docum
 
 	log.WithFields(logrus.Fields{
 		"collection": collectionName,
-		"doc_id":     doc.getID(),
+		"doc_id":     doc.getID().Hex(),
 	}).Debugf("update %v", collectionName)
 	return c.UpdateId(doc.getID(), update)
 }


### PR DESCRIPTION
Close #186 