### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/concurrency/CHANGELOG.md
+++ b/concurrency/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
+
 ## v1.1.0
 
 * Bump github.com/go-utils/logger from v1.0.0 to v1.1.0

--- a/concurrency/go.mod
+++ b/concurrency/go.mod
@@ -1,8 +1,10 @@
 module github.com/Scalingo/go-utils/concurrency
 
-go 1.16
+go 1.17
+
+require github.com/Scalingo/go-utils/logger v1.1.0
 
 require (
-	github.com/Scalingo/go-utils/logger v1.1.0
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
 )

--- a/cronsetup/CHANGELOG.md
+++ b/cronsetup/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump go.etcd.io/etcd/client/v3 from 3.5.0 to 3.5.4
 
 ## v1.1.1

--- a/cronsetup/go.mod
+++ b/cronsetup/go.mod
@@ -1,12 +1,32 @@
 module github.com/Scalingo/go-utils/cronsetup
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-etcd-cron v1.3.0
 	github.com/Scalingo/go-utils/logger v1.1.0
 	go.etcd.io/etcd/client/v3 v3.5.4
+)
+
+require (
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/iancoleman/strcase v0.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.4 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.4 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )
 
 // In Dev you can uncomment the following line to use the local 'logger' package

--- a/difflib/CHANGELOG.md
+++ b/difflib/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## To be Released
 
-* Bump go version to 1.16
+* chore(go): use go 1.17
 
 ## v1.0.0
 

--- a/difflib/go.mod
+++ b/difflib/go.mod
@@ -1,3 +1,3 @@
 module github.com/Scalingo/go-utils/difflib
 
-go 1.16
+go 1.17

--- a/env/CHANGELOG.md
+++ b/env/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ## v1.1.0

--- a/env/go.mod
+++ b/env/go.mod
@@ -1,9 +1,11 @@
 module github.com/Scalingo/go-utils/env
 
-go 1.16
+go 1.17
+
+require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.7.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ## v1.1.0

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,11 +1,15 @@
 module github.com/Scalingo/go-utils/errors
 
-go 1.16
+go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/etcd/CHANGELOG.md
+++ b/etcd/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump go.etcd.io/etcd/client/v3 from 3.5.0 to 3.5.4
 
 ## v1.1.0

--- a/etcd/go.mod
+++ b/etcd/go.mod
@@ -1,9 +1,25 @@
 module github.com/Scalingo/go-utils/etcd
 
-go 1.16
+go 1.17
 
 require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.4
 	go.etcd.io/etcd/client/v3 v3.5.4
+)
+
+require (
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.4 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/fs/CHANGELOG.md
+++ b/fs/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * bump github.com/spf13/afero from 1.5.1 to 1.8.2
-* Bump go version to 1.16
 
 ## v1.0.0 - v1.0.1
 

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -1,5 +1,7 @@
 module github.com/Scalingo/go-utils/fs
 
-go 1.16
+go 1.17
 
 require github.com/spf13/afero v1.8.2
+
+require golang.org/x/text v0.3.4 // indirect

--- a/gomock_generator/CHANGELOG.md
+++ b/gomock_generator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/urfave/cli from 1.22.5 to 1.22.9
 
 ## v1.3.0

--- a/gomock_generator/go.mod
+++ b/gomock_generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/gomock_generator
 
-go 1.16
+go 1.17
 
 // In Dev you can uncomment the following line to use the local 'logger' package
 // replace github.com/Scalingo/go-utils/logger => ../logger
@@ -10,5 +10,11 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.9
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
 )

--- a/graceful/CHANGELOG.md
+++ b/graceful/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ## v1.1.0

--- a/graceful/go.mod
+++ b/graceful/go.mod
@@ -1,17 +1,24 @@
 module github.com/Scalingo/go-utils/graceful
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/logger v1.1.0
+	github.com/facebookgo/grace v0.0.0-20180706040059-75cf19382434
+	github.com/stretchr/testify v1.7.1
+	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
 	github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 // indirect
-	github.com/facebookgo/grace v0.0.0-20180706040059-75cf19382434
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
-	github.com/stretchr/testify v1.7.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
-	gopkg.in/errgo.v1 v1.0.1
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
 // In Dev you can uncomment the following line to use the local 'logger' package

--- a/httpclient/CHANGELOG.md
+++ b/httpclient/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/gofrs/uuid from 3.4.0+incompatible to 4.2.0+incompatible
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 

--- a/httpclient/go.mod
+++ b/httpclient/go.mod
@@ -1,10 +1,14 @@
 module github.com/Scalingo/go-utils/httpclient
 
-go 1.16
+go 1.17
+
+require (
+	github.com/gofrs/uuid v4.2.0+incompatible
+	github.com/stretchr/testify v1.7.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gofrs/uuid v4.2.0+incompatible
-	github.com/stretchr/testify v1.7.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/influx/CHANGELOG.md
+++ b/influx/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 * build(deps): bump github.com/influxdata/influxdb from 1.9.6 to 1.9.7
 

--- a/influx/go.mod
+++ b/influx/go.mod
@@ -1,10 +1,17 @@
 module github.com/Scalingo/go-utils/influx
 
-go 1.16
+go 1.17
 
 require (
 	github.com/influxdata/influxdb v1.9.7
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ## v1.1.0

--- a/io/go.mod
+++ b/io/go.mod
@@ -1,11 +1,15 @@
 module github.com/Scalingo/go-utils/io
 
-go 1.16
+go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/guillermo/go.procmeminfo v0.0.0-20131127224636-be4355a9fb0e
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ## v1.1.0

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -1,11 +1,20 @@
 module github.com/Scalingo/go-utils/logger
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/logrus-rollbar v1.4.0
 	github.com/rollbar/rollbar-go v1.4.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/Scalingo/errgo-rollbar v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/Scalingo/go-utils/errors from 1.0.0 to 1.1.0
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 

--- a/mongo/go.mod
+++ b/mongo/go.mod
@@ -1,18 +1,25 @@
 module github.com/Scalingo/go-utils/mongo
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/errors v1.1.0
 	github.com/Scalingo/go-utils/logger v1.1.0
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
-	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
 // Uncomment if you want to use the local version of these packages (for development purpose)

--- a/nsqconsumer/CHANGELOG.md
+++ b/nsqconsumer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/nsqio/go-nsq from 1.0.8 to 1.1.0
 
 ## v1.1.0

--- a/nsqconsumer/go.mod
+++ b/nsqconsumer/go.mod
@@ -1,15 +1,22 @@
 module github.com/Scalingo/go-utils/nsqconsumer
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/logger v1.1.0
 	github.com/Scalingo/go-utils/nsqproducer v1.1.1
-	github.com/golang/snappy v0.0.2 // indirect
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stvp/rollbar v0.5.1
 	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/Scalingo/go-utils/env v1.0.1 // indirect
+	github.com/gofrs/uuid v3.4.0+incompatible // indirect
+	github.com/golang/snappy v0.0.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
 )
 
 // In Dev you can uncomment the following line to use the local packages

--- a/nsqlbproducer/CHANGELOG.md
+++ b/nsqlbproducer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/Scalingo/go-utils/env from 1.0.1 to 1.1.0
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 

--- a/nsqlbproducer/go.mod
+++ b/nsqlbproducer/go.mod
@@ -1,17 +1,26 @@
 module github.com/Scalingo/go-utils/nsqlbproducer
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/env v1.1.0
 	github.com/Scalingo/go-utils/nsqproducer v1.1.1
 	github.com/golang/mock v1.6.0
-	github.com/golang/snappy v0.0.2 // indirect
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/Scalingo/go-utils/logger v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gofrs/uuid v3.4.0+incompatible // indirect
+	github.com/golang/snappy v0.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
 // In Dev you can uncomment the following line to use the local packages

--- a/nsqproducer/CHANGELOG.md
+++ b/nsqproducer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/gofrs/uuid from 3.4.0+incompatible to 4.2.0+incompatible
 * build(deps): bump github.com/nsqio/go-nsq from 1.0.8 to 1.1.0
 

--- a/nsqproducer/go.mod
+++ b/nsqproducer/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/nsqproducer
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/env v1.1.0
@@ -10,8 +10,12 @@ require (
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
 	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/golang/snappy v0.0.1 // indirect
+	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
 )
 
 // In Dev you can uncomment the following line to use the local packages

--- a/publicgen/CHANGELOG.md
+++ b/publicgen/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * Bump go version to 1.16 and replace ioutil by io/os [#198](https://github.com/Scalingo/go-utils/pull/198)
 
 ## v1.0.0

--- a/publicgen/go.mod
+++ b/publicgen/go.mod
@@ -1,3 +1,3 @@
 module github.com/Scalingo/go-utils/publicgen
 
-go 1.16
+go 1.17

--- a/retry/CHANGELOG.md
+++ b/retry/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ## v1.1.0

--- a/retry/go.mod
+++ b/retry/go.mod
@@ -1,9 +1,11 @@
 module github.com/Scalingo/go-utils/retry
 
-go 1.16
+go 1.17
+
+require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.7.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/storage/CHANGELOG.md
+++ b/storage/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/aws/aws-sdk-go-v2 from 1.9.2 to 1.16.4
 * build(deps): bump github.com/aws/aws-sdk-go-v2/credentials from 1.6.3 to 1.12.4
 * build(deps): bump github.com/aws/aws-sdk-go-v2/feature/s3/manager from 1.5.4 to 1.11.14

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/storage
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/logger v1.1.0
@@ -13,7 +13,23 @@ require (
 	github.com/ncw/swift v1.0.53
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.11 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
 // In Dev you can uncomment the following line to use the local 'logger' package

--- a/tarball/CHANGELOG.md
+++ b/tarball/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * build(deps): bump github.com/Scalingo/go-utils/io from 1.0.0 to 1.1.0
 * build(deps): bump github.com/spf13/afero from 1.6.0 to 1.8.2
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1

--- a/tarball/go.mod
+++ b/tarball/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/tarball
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/go-utils/fs v1.0.0
@@ -10,4 +10,13 @@ require (
 	github.com/spf13/afero v1.8.2
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
+	golang.org/x/text v0.3.4 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.