### PR TITLE
feat(mongo): contextify mongo.Session

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* feat(mongo): contextify mongo.Session [#396](https://github.com/Scalingo/go-utils/pull/396)
 * build(deps): bump github.com/Scalingo/go-utils/logger from 1.1.1 to 1.2.0
 * build(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -4,11 +4,11 @@ Useful tools around MongoDB.
 
 ```go
 mongo.DefaultDatabaseName = "default-database"
-mongo.Session(logger.Default())
+mongo.Session(context.Background())
 ```
 
 Create a new session based on `MONGO_URL`, connection will be initialized only
-once, so you can call it everytime your need a session.
+once, so you can call it every time your need a session.
 
 Will wait until database is available.
 


### PR DESCRIPTION
Without this change, our linter complains in all calling codes about the use of `context.Background` here. And I must say that I find it odd to pass the logger rather than the context here. @soulou Do you know if there is a reason about that?

This change should lead to a new major version of this lib


- [x] Add a changelog entry in `CHANGELOG.md`