### PR TITLE
Revert "fix(storage): NotFoundErrCode should be 404 not a string 'NotFound'"

### DIFF
--- a/storage/CHANGELOG.md
+++ b/storage/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## To be Released
 
 * feat: add Info method, it returns object information and ObjectNotFound custom error in case of object not found [393](https://github.com/Scalingo/go-utils/pull/393)
-* fix(s3): NotFoundErrCode is 404 not the string "NotFound" [393](https://github.com/Scalingo/go-utils/pull/393)
 * build(deps): bump github.com/Scalingo/go-utils/logger from 1.1.1 to 1.2.0
 * build(deps): bump github.com/aws/aws-sdk-go-v2 from 1.16.4 to 1.16.16
 * build(deps): bump github.com/aws/aws-sdk-go-v2/credentials from 1.12.4 to 1.12.21

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	NotFoundErrCode = "404"
+	NotFoundErrCode = "NotFound"
 	// DefaultPartSize 16 MB part size define the size in bytes of the parts
 	// uploaded in a multipart upload
 	DefaultPartSize = int64(16777216)

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -65,7 +65,7 @@ func TestS3_Size(t *testing.T) {
 					Bucket: aws.String("bucket"), Key: aws.String("key"),
 				}).Return(nil, KeyNotFoundErr{}).Times(3)
 			},
-			err: "404",
+			err: "NotFound",
 		},
 	}
 	for title, c := range cases {
@@ -107,8 +107,8 @@ func TestS3_Info(t *testing.T) {
 				m.EXPECT().HeadObject(gomock.Any(), &s3.HeadObjectInput{
 					Bucket: aws.String("bucket"), Key: aws.String(key),
 				}).Return(nil, &smithy.GenericAPIError{
-					Code:    "404",
-					Message: "NotFound",
+					Code:    "NotFound",
+					Message: "Not Found",
 				})
 			},
 			key:          "unknown_key",


### PR DESCRIPTION
This reverts commit e8eaca7380b8ae24975c3033a3b51cfd67518f76.
This is a regression due to my local s3 client version.

- [x] Add a changelog entry in `CHANGELOG.md`