### PR TITLE
docs(readme): instructions to register the rollbarplugin

### DIFF
--- a/logger/plugins/rollbarplugin/README.md
+++ b/logger/plugins/rollbarplugin/README.md
@@ -4,15 +4,19 @@ This plugin will send every log with a level >= Error to rollbar.
 
 ## Configuration
 
-This plugin need two different environment variables:
+This plugin needs two different environment variables:
 
 * `ROLLBAR_TOKEN`: The rollbar token used to authenticate against the Rollbar API
 * `GO_ENV`: The go environment
 
 # Usage
 
-To use it add this to your main:
+To use this plugin, register it during the initialization of your program.
 
-```
+/!\ This line MUST be written BEFORE the first initialization of the logger.
+
+```go
 rollbarplugin.Register()
+log := logger.Default()
+ctx := logger.ToCtx(context.Background(), log)
 ```


### PR DESCRIPTION
The Rollbar plugin requires to be registered before instantiating the logger.