### PR TITLE
feat(errors): add method New to ErrCtx

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To be Released
 
 * feat: add New method to `ErrCtx`
+* feat: IsRootCause and RootCause are taking in account `ErrCtx` underlying errors
 
 ## v2.0.0
 

--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* feat: add New method to `ErrCtx`
+
 ## v2.0.0
 
 * fix: privatify `ErrgoRoot`

--- a/errors/cause.go
+++ b/errors/cause.go
@@ -2,8 +2,6 @@ package errors
 
 import (
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 // IsRootCause return true if the cause of the given error is the same type as
@@ -16,7 +14,7 @@ import (
 //	errors.IsRootCause(err, &ValidationErrors{})
 func IsRootCause(err error, mytype interface{}) bool {
 	t := reflect.TypeOf(mytype)
-	errCause := errors.Cause(err)
+	errCause := errorCause(err)
 	errRoot := errgoRoot(err)
 	return reflect.TypeOf(errCause) == t || reflect.TypeOf(errRoot) == t
 }
@@ -24,7 +22,7 @@ func IsRootCause(err error, mytype interface{}) bool {
 // RootCause returns the cause of an errors stack, whatever the method they used
 // to be stacked: either errgo.Notef or errors.Wrapf.
 func RootCause(err error) error {
-	errCause := errors.Cause(err)
+	errCause := errorCause(err)
 	if errCause == nil {
 		errCause = errgoRoot(err)
 	}

--- a/errors/cause_test.go
+++ b/errors/cause_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -26,6 +27,23 @@ func Test_IsRootCause(t *testing.T) {
 		assert.True(t, IsRootCause(err, &ValidationErrors{}))
 		assert.False(t, IsRootCause(err, ValidationErrors{}))
 	})
+
+	t.Run("given an error stack with Wrapf from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = Wrapf(context.Background(), err, "biniou")
+
+		assert.True(t, IsRootCause(err, &ValidationErrors{}))
+		assert.False(t, IsRootCause(err, ValidationErrors{}))
+	})
+	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = Notef(context.Background(), err, "biniou")
+
+		assert.True(t, IsRootCause(err, &ValidationErrors{}))
+		assert.False(t, IsRootCause(err, ValidationErrors{}))
+	})
 }
 
 func Test_RootCause(t *testing.T) {
@@ -33,7 +51,7 @@ func Test_RootCause(t *testing.T) {
 		var err error
 		err = (&ValidationErrors{
 			Errors: map[string][]string{
-				"test": []string{"biniou"},
+				"test": {"biniou"},
 			},
 		})
 		err = errgo.Mask(err, errgo.Any)
@@ -45,7 +63,7 @@ func Test_RootCause(t *testing.T) {
 		var err error
 		err = (&ValidationErrors{
 			Errors: map[string][]string{
-				"test": []string{"biniou"},
+				"test": {"biniou"},
 			},
 		})
 		err = errgo.Notef(err, "pouet")
@@ -57,10 +75,34 @@ func Test_RootCause(t *testing.T) {
 		var err error
 		err = (&ValidationErrors{
 			Errors: map[string][]string{
-				"test": []string{"biniou"},
+				"test": {"biniou"},
 			},
 		})
 		err = errors.Wrap(err, "pouet")
+
+		assert.Equal(t, "test=biniou", RootCause(err).Error())
+	})
+
+	t.Run("given an error stack with Wrapf from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{
+			Errors: map[string][]string{
+				"test": {"biniou"},
+			},
+		})
+		err = Wrapf(context.Background(), err, "pouet")
+
+		assert.Equal(t, "test=biniou", RootCause(err).Error())
+	})
+
+	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{
+			Errors: map[string][]string{
+				"test": {"biniou"},
+			},
+		})
+		err = Notef(context.Background(), err, "pouet")
 
 		assert.Equal(t, "test=biniou", RootCause(err).Error())
 	})

--- a/errors/cause_test.go
+++ b/errors/cause_test.go
@@ -19,10 +19,37 @@ func Test_IsRootCause(t *testing.T) {
 		assert.False(t, IsRootCause(err, ValidationErrors{}))
 	})
 
+	t.Run("given an error stack with errgo.NoteMask", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = errgo.NoteMask(err, "biniou")
+
+		assert.True(t, IsRootCause(err, &ValidationErrors{}))
+		assert.False(t, IsRootCause(err, ValidationErrors{}))
+	})
+
+	t.Run("given an error stack with errors.Wrap", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = errors.Wrap(err, "biniou")
+
+		assert.True(t, IsRootCause(err, &ValidationErrors{}))
+		assert.False(t, IsRootCause(err, ValidationErrors{}))
+	})
+
 	t.Run("given an error stack with errors.Wrapf", func(t *testing.T) {
 		var err error
 		err = (&ValidationErrors{})
 		err = errors.Wrapf(err, "biniou")
+
+		assert.True(t, IsRootCause(err, &ValidationErrors{}))
+		assert.False(t, IsRootCause(err, ValidationErrors{}))
+	})
+
+	t.Run("given an error stack with Wrap from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = Wrap(context.Background(), err, "biniou")
 
 		assert.True(t, IsRootCause(err, &ValidationErrors{}))
 		assert.False(t, IsRootCause(err, ValidationErrors{}))
@@ -36,10 +63,20 @@ func Test_IsRootCause(t *testing.T) {
 		assert.True(t, IsRootCause(err, &ValidationErrors{}))
 		assert.False(t, IsRootCause(err, ValidationErrors{}))
 	})
+
 	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
 		var err error
 		err = (&ValidationErrors{})
 		err = Notef(context.Background(), err, "biniou")
+
+		assert.True(t, IsRootCause(err, &ValidationErrors{}))
+		assert.False(t, IsRootCause(err, ValidationErrors{}))
+	})
+
+	t.Run("given an error stack with NoteMask from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = NoteMask(context.Background(), err, "biniou")
 
 		assert.True(t, IsRootCause(err, &ValidationErrors{}))
 		assert.False(t, IsRootCause(err, ValidationErrors{}))
@@ -71,6 +108,18 @@ func Test_RootCause(t *testing.T) {
 		assert.Equal(t, "test=biniou", RootCause(err).Error())
 	})
 
+	t.Run("given an error stack with errgo.NoteMask", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{
+			Errors: map[string][]string{
+				"test": {"biniou"},
+			},
+		})
+		err = errgo.NoteMask(err, "pouet")
+
+		assert.Equal(t, "test=biniou", RootCause(err).Error())
+	})
+
 	t.Run("given an error stack with errors.Wrap", func(t *testing.T) {
 		var err error
 		err = (&ValidationErrors{
@@ -79,6 +128,18 @@ func Test_RootCause(t *testing.T) {
 			},
 		})
 		err = errors.Wrap(err, "pouet")
+
+		assert.Equal(t, "test=biniou", RootCause(err).Error())
+	})
+
+	t.Run("given an error stack with Wrap from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{
+			Errors: map[string][]string{
+				"test": {"biniou"},
+			},
+		})
+		err = Wrap(context.Background(), err, "pouet")
 
 		assert.Equal(t, "test=biniou", RootCause(err).Error())
 	})
@@ -103,6 +164,18 @@ func Test_RootCause(t *testing.T) {
 			},
 		})
 		err = Notef(context.Background(), err, "pouet")
+
+		assert.Equal(t, "test=biniou", RootCause(err).Error())
+	})
+
+	t.Run("given an error stack with NoteMask from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{
+			Errors: map[string][]string{
+				"test": {"biniou"},
+			},
+		})
+		err = NoteMask(context.Background(), err, "pouet")
 
 		assert.Equal(t, "test=biniou", RootCause(err).Error())
 	})

--- a/errors/errctx.go
+++ b/errors/errctx.go
@@ -21,6 +21,10 @@ func (err ErrCtx) Ctx() context.Context {
 	return err.ctx
 }
 
+func Newf(ctx context.Context, format string, args ...interface{}) error {
+	return ErrCtx{ctx: ctx, err: errgo.Newf(format, args...)}
+}
+
 func Notef(ctx context.Context, err error, format string, args ...interface{}) error {
 	return ErrCtx{ctx: ctx, err: errgo.Notef(err, format, args...)}
 }

--- a/errors/errctx.go
+++ b/errors/errctx.go
@@ -21,14 +21,30 @@ func (err ErrCtx) Ctx() context.Context {
 	return err.ctx
 }
 
+func New(ctx context.Context, message string) error {
+	return ErrCtx{ctx: ctx, err: errgo.New(message)}
+}
+
 func Newf(ctx context.Context, format string, args ...interface{}) error {
 	return ErrCtx{ctx: ctx, err: errgo.Newf(format, args...)}
+}
+
+func NoteMask(ctx context.Context, err error, message string) error {
+	return ErrCtx{ctx: ctx, err: errgo.NoteMask(err, message)}
 }
 
 func Notef(ctx context.Context, err error, format string, args ...interface{}) error {
 	return ErrCtx{ctx: ctx, err: errgo.Notef(err, format, args...)}
 }
 
+func Wrap(ctx context.Context, err error, message string) error {
+	return ErrCtx{ctx: ctx, err: errors.Wrap(err, message)}
+}
+
 func Wrapf(ctx context.Context, err error, format string, args ...interface{}) error {
 	return ErrCtx{ctx: ctx, err: errors.Wrapf(err, format, args...)}
+}
+
+func Errorf(ctx context.Context, format string, args ...interface{}) error {
+	return ErrCtx{ctx: ctx, err: errors.Errorf(format, args...)}
 }

--- a/errors/errgo.go
+++ b/errors/errgo.go
@@ -1,16 +1,22 @@
 package errors
 
-import "gopkg.in/errgo.v1"
+import (
+	"gopkg.in/errgo.v1"
+)
 
 func errgoRoot(err error) error {
 	for {
-		e, ok := err.(*errgo.Err)
+		e, ok := err.(ErrCtx)
+		if ok {
+			err = e.err
+		}
+		errgoErr, ok := err.(*errgo.Err)
 		if !ok {
 			return err
 		}
-		if e.Underlying() == nil {
+		if errgoErr.Underlying() == nil {
 			return err
 		}
-		err = e.Underlying()
+		err = errgoErr.Underlying()
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,21 @@
+package errors
+
+func errorCause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		e, ok := err.(ErrCtx)
+		if ok {
+			err = e.err
+		}
+
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}


### PR DESCRIPTION
- [x] Add a changelog entry in `CHANGELOG.md`

This PR adds a `New` method to ErrCtx
Also, make the `RootCause` and `IsRootCause` to unwrap underlying errors.

To see an example of its implementation, you can check these PRs:
- https://github.com/Scalingo/metrics-storage-service/pull/146
- https://github.com/Scalingo/logs-archive-service/pull/135

Fix #442 