### PR TITLE
Bump nsqconsumer to v1.2.0: better error management

### DIFF
--- a/nsqconsumer/CHANGELOG.md
+++ b/nsqconsumer/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+## v1.2.0
+
 * feat: Start unwraps errors to find noRetry field that can be wrapped in ErrCtx. Also use ErrCtx to enrich the logger
 * build(deps): bump github.com/Scalingo/go-utils/logger from 1.1.1 to 1.2.0
 * build(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0

--- a/nsqconsumer/README.md
+++ b/nsqconsumer/README.md
@@ -1,1 +1,1 @@
-# Package `nsqconsumer` v1.1.1
+# Package `nsqconsumer` v1.2.0


### PR DESCRIPTION
- [x] Add a changelog entry in `CHANGELOG.md`