### PR TITLE
test(io): don't check the exact system cache size

### DIFF
--- a/io/copier_test.go
+++ b/io/copier_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +40,8 @@ func TestCopier_Copy(t *testing.T) {
 		_, err = src.WriteString("hello")
 		require.NoError(t, err)
 		// Get back the reader at the beginning of the file
-		src.Seek(0, os.SEEK_SET)
+		_, err = src.Seek(0, io.SeekStart)
+		require.NoError(t, err)
 
 		copier := NewCopier()
 		n, err := copier.Copy(dst, src)
@@ -73,7 +75,8 @@ func TestCopier_Copy(t *testing.T) {
 		}
 
 		// Get back the reader at the beginning of the file
-		src.Seek(0, os.SEEK_SET)
+		_, err = src.Seek(0, io.SeekStart)
+		require.NoError(t, err)
 
 		copier := NewCopier(WithNoDiskCache)
 		_, err = copier.Copy(dst, src)

--- a/io/copier_test.go
+++ b/io/copier_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	procmeminfo "github.com/guillermo/go.procmeminfo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,27 +75,10 @@ func TestCopier_Copy(t *testing.T) {
 		// Get back the reader at the beginning of the file
 		src.Seek(0, os.SEEK_SET)
 
-		mi := &procmeminfo.MemInfo{}
-		mi.Update()
-		cachedBefore := (*mi)["Cached"]
-
 		copier := NewCopier(WithNoDiskCache)
 		_, err = copier.Copy(dst, src)
 		require.NoError(t, err)
 		require.NoError(t, dst.Close())
 		require.NoError(t, src.Close())
-
-		mi.Update()
-		cachedAfter := (*mi)["Cached"]
-
-		// If the cache diff is negative, we're all good
-		// If it's positive, let's consider it's noise from the system
-		// And we want to check it's not more than the 110MB of our fixture
-		if cachedAfter > cachedBefore {
-			cacheDiff := cachedAfter - cachedBefore
-			// Let's say we want to check the difference of cache is only of 110MB,
-			// indeed it can't be insured since it's global to the system
-			assert.True(t, cacheDiff < 110*1024*1024, "expected diff of cache < 110MB, was %vMB", cacheDiff/1024/1024)
-		}
 	})
 }

--- a/io/go.mod
+++ b/io/go.mod
@@ -3,6 +3,7 @@ module github.com/Scalingo/go-utils/io
 go 1.17
 
 require (
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/sys v0.5.0
 )

--- a/io/go.mod
+++ b/io/go.mod
@@ -3,7 +3,6 @@ module github.com/Scalingo/go-utils/io
 go 1.17
 
 require (
-	github.com/guillermo/go.procmeminfo v0.0.0-20131127224636-be4355a9fb0e
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/sys v0.5.0
 )

--- a/io/go.sum
+++ b/io/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/io/go.sum
+++ b/io/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/guillermo/go.procmeminfo v0.0.0-20131127224636-be4355a9fb0e h1:/6/OurM62Ddm8CR8PveE0a+ql2mL+ycAhOwd563kpdg=
-github.com/guillermo/go.procmeminfo v0.0.0-20131127224636-be4355a9fb0e/go.mod h1:TQrLAmkOSnZ4g1eFORtCfTEbFuVZD0Zm55vdnrilBaw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
The current test is flakky. From past failed executions, it can go up to 230MB. Let's remove this test.


Fix #548

- [ ] Add a changelog entry in `CHANGELOG.md`
  => n/a, only test changes