### PR TITLE
feat(Is/As) Match API from standard library and leverage it to check for error value of type

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* feat: add `Is` and `As` to match standard library
 * fix: remove `NoteMask`. `Notef` should be use instead.
 
 ## v2.2.0

--- a/errors/cause.go
+++ b/errors/cause.go
@@ -39,6 +39,8 @@ func As(receivedErr error, expectedType any) bool {
 
 // RootCause returns the cause of an errors stack, whatever the method they used
 // to be stacked: either errgo.Notef or errors.Wrapf.
+//
+// Deprecated: Use `Is(err, expectedErr)` instead of `if RootCause(err) == expectedErr` to match go standard libraries practices
 func RootCause(err error) error {
 	errCause := errorCause(err)
 	if errCause == nil {
@@ -55,6 +57,8 @@ func RootCause(err error) error {
 // Example:
 //
 //	errors.IsRootCause(err, &ValidationErrors{})
+//
+// Deprecated: Use `As(err, mytype)` instead to match go standard libraries practices
 func IsRootCause(err error, mytype interface{}) bool {
 	t := reflect.TypeOf(mytype)
 	errCause := errorCause(err)

--- a/errors/cause.go
+++ b/errors/cause.go
@@ -1,10 +1,51 @@
 package errors
 
 import (
+	"errors"
 	"reflect"
 
 	"gopkg.in/errgo.v1"
 )
+
+// Is checks if any error of the stack matches the error value expectedError
+// API machting the standard library but allowing to wrap errors with ErrCtx + errgo or pkg/errors
+func Is(receivedErr, expectedError error) bool {
+	if errors.Is(receivedErr, expectedError) {
+		return true
+	}
+	for receivedErr != nil {
+		receivedErr = UnwrapError(receivedErr)
+		if errors.Is(receivedErr, expectedError) {
+			return true
+		}
+	}
+	return false
+}
+
+// As checks if any error of the stack matches the expectedType
+// API machting the standard library but allowing to wrap errors with ErrCtx + errgo or pkg/errors
+func As(receivedErr error, expectedType any) bool {
+	if errors.As(receivedErr, expectedType) {
+		return true
+	}
+	for receivedErr != nil {
+		receivedErr = UnwrapError(receivedErr)
+		if errors.As(receivedErr, expectedType) {
+			return true
+		}
+	}
+	return false
+}
+
+// RootCause returns the cause of an errors stack, whatever the method they used
+// to be stacked: either errgo.Notef or errors.Wrapf.
+func RootCause(err error) error {
+	errCause := errorCause(err)
+	if errCause == nil {
+		errCause = errgoRoot(err)
+	}
+	return errCause
+}
 
 // IsRootCause return true if the cause of the given error is the same type as
 // mytype.
@@ -19,16 +60,6 @@ func IsRootCause(err error, mytype interface{}) bool {
 	errCause := errorCause(err)
 	errRoot := errgoRoot(err)
 	return reflect.TypeOf(errCause) == t || reflect.TypeOf(errRoot) == t
-}
-
-// RootCause returns the cause of an errors stack, whatever the method they used
-// to be stacked: either errgo.Notef or errors.Wrapf.
-func RootCause(err error) error {
-	errCause := errorCause(err)
-	if errCause == nil {
-		errCause = errgoRoot(err)
-	}
-	return errCause
 }
 
 // UnwrapError tries to unwrap `err`. It unwraps any causer type, errgo and ErrCtx errors.

--- a/errors/cause_test.go
+++ b/errors/cause_test.go
@@ -2,12 +2,142 @@ package errors
 
 import (
 	"context"
+	"io"
+	"net"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	errgo "gopkg.in/errgo.v1"
 )
+
+type customError struct {
+	WrappedError error
+	CustomValue  string
+}
+
+func (err *customError) Error() string {
+	return "custom error " + err.CustomValue
+}
+
+func (err *customError) Unwrap() error {
+	return err.WrappedError
+}
+
+func Test_As(t *testing.T) {
+	var expectedErrorType *ValidationErrors
+	var unexpectedErrorType *net.OpError
+	t.Run("given an error stack with errgo.Notef", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = errgo.Notef(err, "biniou")
+
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+
+	t.Run("given an error stack with errors.Wrap", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = errors.Wrap(err, "biniou")
+
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+
+	t.Run("given an error stack with errors.Wrapf", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = errors.Wrapf(err, "biniou")
+
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+
+	t.Run("given an error stack with Wrap from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = Wrap(context.Background(), err, "biniou")
+
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+
+	t.Run("given an error stack with Wrapf from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = Wrapf(context.Background(), err, "biniou")
+
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+
+	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
+		var err error
+		err = (&ValidationErrors{})
+		err = Notef(context.Background(), err, "biniou")
+
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+
+	t.Run("given an error in the middle of the stack stack with Notef from ErrCtx", func(t *testing.T) {
+		var err error
+		err = io.EOF
+		err = &customError{WrappedError: err, CustomValue: "value"}
+		err = Notef(context.Background(), err, "biniou")
+
+		var expectedErrorType *customError
+		assert.True(t, As(err, &expectedErrorType))
+		assert.False(t, As(err, &unexpectedErrorType))
+	})
+}
+
+func Test_Is(t *testing.T) {
+	t.Run("given an error stack with errgo.Mask", func(t *testing.T) {
+		expectedError := io.EOF
+		err := errgo.Mask(expectedError, errgo.Any)
+
+		assert.True(t, Is(err, expectedError))
+	})
+
+	t.Run("given an error stack with errgo.Notef", func(t *testing.T) {
+		expectedError := io.EOF
+		err := errgo.Notef(expectedError, "pouet")
+
+		assert.True(t, Is(err, expectedError))
+	})
+
+	t.Run("given an error stack with errors.Wrap", func(t *testing.T) {
+		expectedError := io.EOF
+		err := errors.Wrap(expectedError, "pouet")
+
+		assert.True(t, Is(err, expectedError))
+	})
+
+	t.Run("given an error stack with Wrap from ErrCtx", func(t *testing.T) {
+		expectedError := io.EOF
+		err := Wrap(context.Background(), expectedError, "pouet")
+
+		assert.True(t, Is(err, expectedError))
+	})
+
+	t.Run("given an error stack with Wrapf from ErrCtx", func(t *testing.T) {
+		expectedError := io.EOF
+		err := Wrapf(context.Background(), expectedError, "pouet")
+
+		assert.True(t, Is(err, expectedError))
+	})
+
+	t.Run("given an error stack with mixed types", func(t *testing.T) {
+		expectedError := io.EOF
+		err := Notef(context.Background(), expectedError, "pouet")
+		err = errgo.Notef(err, "pouet")
+		err = errors.Wrap(err, "pouet")
+
+		assert.True(t, Is(err, expectedError))
+	})
+}
 
 func Test_IsRootCause(t *testing.T) {
 	t.Run("given an error stack with errgo.Notef", func(t *testing.T) {

--- a/errors/errctx.go
+++ b/errors/errctx.go
@@ -20,6 +20,11 @@ func (err ErrCtx) Ctx() context.Context {
 	return err.ctx
 }
 
+// Unwrap implements error management from the standard library
+func (err ErrCtx) Unwrap() error {
+	return err.err
+}
+
 func New(ctx context.Context, message string) error {
 	return ErrCtx{ctx: ctx, err: errgo.New(message)}
 }

--- a/graceful/main_test.go
+++ b/graceful/main_test.go
@@ -13,7 +13,7 @@ func TestMain(m *testing.M) {
 }
 
 func buildServer() {
-	err := exec.Command("go", "build", "-i", "-o", "./testdata/server", "./testdata/cmd/server").Run()
+	err := exec.Command("go", "build", "-o", "./testdata/server", "./testdata/cmd/server").Run()
 	if err != nil {
 		log.Println("Fail to build test server", err)
 		os.Exit(1)


### PR DESCRIPTION
I'm proposing to deprecate `IsRootCause(err, errWithExpectedType)` and `if(errors.RootCause(err) == something` to use `errors.As(err, errWithExpectedType)` and `errors.Is(err, something)`, to match idiomatic Go practices

Fixes #582

- [x] Add a changelog entry in `CHANGELOG.md`