### PR TITLE
[etcd] Bump v1.1.2

### DIFF
--- a/etcd/CHANGELOG.md
+++ b/etcd/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## To be Released
 
-* build(deps): bump go.etcd.io/etcd/client/v3 from 3.5.4 to 3.5.6
+## v1.1.2
+
+* Various dependencies updates
 
 ## v1.1.1
 

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -1,3 +1,3 @@
-# Package `etcd` v1.1.1
+# Package `etcd` v1.1.2
 
 The package `etcd` contains a builder for an etcd client.


### PR DESCRIPTION
In order to release security fix from https://github.com/Scalingo/go-utils/pull/785

- [x] Add a changelog entry in `CHANGELOG.md`