### PR TITLE
docs(errors): deprecate use of `errgo` in `ErrCtx`

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* docs(errors): deprecate use of `errgo` in `ErrCtx`
+
 ## v2.3.0
 
 * feat: add `Is` and `As` to match standard library

--- a/errors/errctx.go
+++ b/errors/errctx.go
@@ -33,6 +33,7 @@ func Newf(ctx context.Context, format string, args ...interface{}) error {
 	return ErrCtx{ctx: ctx, err: errgo.Newf(format, args...)}
 }
 
+// Deprecated: Use `Wrap` or `Wrapf` instead of `Notef`. The library is able to unwrap mixed errors (wrapped with `errgo` or `github.com/pkg/errors`).
 func Notef(ctx context.Context, err error, format string, args ...interface{}) error {
 	return ErrCtx{ctx: ctx, err: errgo.Notef(err, format, args...)}
 }

--- a/errors/errctx.go
+++ b/errors/errctx.go
@@ -26,11 +26,11 @@ func (err ErrCtx) Unwrap() error {
 }
 
 func New(ctx context.Context, message string) error {
-	return ErrCtx{ctx: ctx, err: errgo.New(message)}
+	return ErrCtx{ctx: ctx, err: errors.New(message)}
 }
 
 func Newf(ctx context.Context, format string, args ...interface{}) error {
-	return ErrCtx{ctx: ctx, err: errgo.Newf(format, args...)}
+	return Errorf(ctx, format, args...)
 }
 
 // Deprecated: Use `Wrap` or `Wrapf` instead of `Notef`. The library is able to unwrap mixed errors (wrapped with `errgo` or `github.com/pkg/errors`).


### PR DESCRIPTION
- [x] Add a changelog entry in `CHANGELOG.md`