### PR TITLE
Remove go patch version from go.mod (1.22.4 => 1.22)

### DIFF
--- a/graceful/go.mod
+++ b/graceful/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/graceful
 
-go 1.22.4
+go 1.22
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0


### PR DESCRIPTION
Related to [swan-agent PR#36](https://github.com/Scalingo/swan-agent/pull/36)