### PR TITLE
gomock_generator. Add --source-path option

### DIFF
--- a/gomock_generator/gomockgenerator/package.go
+++ b/gomock_generator/gomockgenerator/package.go
@@ -7,15 +7,14 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 )
 
-func interfaceHash(pkg, iName string) (string, error) {
-	sig, err := interfaceSignature(pkg, iName)
+func interfaceHash(fullPath, pkg, iName string) (string, error) {
+	sig, err := interfaceSignature(fullPath, pkg, iName)
 	if err != nil {
 		return "", errors.Wrapf(err, "fail to get interface signature for %s:%s", pkg, iName)
 	}
@@ -26,12 +25,11 @@ func interfaceHash(pkg, iName string) (string, error) {
 	return fmt.Sprintf("% x", hash), nil
 }
 
-func interfaceSignature(pkg, iName string) (string, error) {
+func interfaceSignature(fullPath, pkg, iName string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", errors.Wrap(err, "fail to get current working directory")
 	}
-	fullPath := path.Join(os.Getenv("GOPATH"), "src", pkg)
 	vendoredPkg := filepath.Join(cwd, "vendor", pkg)
 	if _, err := os.Stat(vendoredPkg); err == nil {
 		fullPath = vendoredPkg

--- a/gomock_generator/main.go
+++ b/gomock_generator/main.go
@@ -42,6 +42,7 @@ Reads the mymocks.json file from the current directory and generates the mocks, 
 	app.cli.Flags = []cli.Flag{
 		cli.StringFlag{Name: "mocks-filepath", Value: "./mocks.json", Usage: "Path to the JSON file containing the MockConfiguration. Location of this file is the base package.", EnvVar: "MOCKS_FILEPATH"},
 		cli.StringFlag{Name: "signatures-filename", Value: "mocks_sig.json", Usage: "Filename of the signatures cache. Location of this file is the base package.", EnvVar: "SIGNATURES_FILENAME"},
+		cli.StringFlag{Name: "source-path", Value: "", Usage: "Path to the local source code", EnvVar: "SOURCE_PATH"},
 		cli.IntFlag{Name: "concurrent-goroutines", Value: 4, Usage: "Concurrent amount of goroutines to generate mock.", EnvVar: "CONCURRENT_GOROUTINES"},
 		cli.BoolFlag{Name: "debug", Usage: "Activate debug logs"},
 	}
@@ -66,6 +67,7 @@ VERSION:
    {{end}}
 `
 	app.cli.Before = func(c *cli.Context) error {
+		app.config.SourcePath = c.GlobalString("source-path")
 		app.config.MocksFilePath = c.GlobalString("mocks-filepath")
 		app.config.SignaturesFilename = c.GlobalString("signatures-filename")
 		app.config.ConcurrentGoroutines = c.GlobalInt("concurrent-goroutines")
@@ -87,6 +89,7 @@ VERSION:
 			"mocks_file_path":       app.config.MocksFilePath,
 			"signatures_filename":   app.config.SignaturesFilename,
 			"concurrent_goroutines": app.config.ConcurrentGoroutines,
+			"source-path":           app.config.SourcePath,
 		}).Info("Configuration for this mocks generation")
 
 		rawFile, err := os.Open(app.config.MocksFilePath)


### PR DESCRIPTION
- [ ] Add a changelog entry in `CHANGELOG.md`

Add a --source-path option that allows for the user to specify the location of their codebase.

e.g. gomocks_generator --source-path <path_to_codebase>