### PR TITLE
fix(logger): Remove custom type from logger context key

### DIFF
--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* fix(logger): remove custom type (use string) for logger context key
+
 ## v1.3.0
 
 * feat(logger): Add configuration option to redact sensitive fields

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,9 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type ContextKey string
-
-const loggerContextKey ContextKey = "logger"
+const loggerContextKey = "logger"
 
 // Opt is a function-option type for the Default() method.
 type Opt func(*logrus.Logger)


### PR DESCRIPTION
This PR removes the recent addition of a custom type. It instead uses the string type for the loggerContextKey

A bug was introduced because the string and the custom type (with underlying string type) are not treated as the same type.

- [ ] Add a changelog entry in `CHANGELOG.md`
