### PR TITLE
Use github.com/Scalingo/go-utils/logger API instead of injecting logger manually in context

### DIFF
--- a/nsqconsumer/CHANGELOG.md
+++ b/nsqconsumer/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* fix: Use API for github.com/go-utils/logger instead of setting logger manually in context
+
 ## v1.3.0
 
 * feat: add a configurable log level

--- a/nsqconsumer/consumer.go
+++ b/nsqconsumer/consumer.go
@@ -266,7 +266,7 @@ func (c *nsqConsumer) nsqHandler(message *nsq.Message) (err error) {
 
 	// Ignore linter here due to the usage of string as keys in context.
 	//nolint:staticcheck,revive
-	ctx := context.WithValue(context.WithValue(context.Background(), "request_id", msg.RequestID), "logger", msgLogger)
+	ctx := logger.ToCtx(context.WithValue(context.Background(), "request_id", msg.RequestID), msgLogger)
 
 	if msg.At != 0 {
 		now := time.Now().Unix()


### PR DESCRIPTION
Fixes #1023

- [x] Add a changelog entry in `CHANGELOG.md`