### PR TITLE
[STORY-1378] Allow getting internal data of nsqconsumer.Error for better testability

### DIFF
--- a/nsqconsumer/CHANGELOG.md
+++ b/nsqconsumer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## To be Released
 
+* feat: nsqconsumer.Error - `Unwrap` method to be compatible with `errors.Is/As()`
+* feat: nsqconsumer.Error - `NoRetry` to get if the message should be retried or not to be consumed.
+
 ## v1.3.1
 
 * fix: Use API for github.com/go-utils/logger instead of setting logger manually in context

--- a/nsqconsumer/consumer.go
+++ b/nsqconsumer/consumer.go
@@ -83,6 +83,16 @@ func (nsqerr Error) Error() string {
 	return nsqerr.error.Error()
 }
 
+// Unwrap returns the cause of the error to be compatible with errors.As/Is()
+func (nsqerr Error) Unwrap() error {
+	return nsqerr.error
+}
+
+// NoRetry returns true if the message should not be retried to be handled
+func (nsqerr Error) NoRetry() bool {
+	return nsqerr.noRetry
+}
+
 type ErrorOpts struct {
 	NoRetry bool
 }


### PR DESCRIPTION
- [x] Add a changelog entry in `CHANGELOG.md`