### PR TITLE
feature(s3) Use the retrier options to configure the AWS SDK

### DIFF
--- a/storage/CHANGELOG.md
+++ b/storage/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* feat(s3): Pass the retry options to the AWS SDK on top of our custom retrier.
+
 ## v1.5.1
 
 * build(deps): rollback github.com/aws/aws-sdk-go-v2 to v1.32.0


### PR DESCRIPTION
Related to https://github.com/Scalingo/project-items/issues/785

The issue with the current retrier is that it only works on simple retryable operations (like Size, Info, etc.). However on complex operations (like a Multipart upload) we implemented no retries and did let the default AWS SDK options (3 retries).
This PR aims to align the SDK retry options with the ones configured on our custom retrier.

- [x] Add a changelog entry in `CHANGELOG.md`