### PR TITLE
fix(otel): Use OTEL_METRIC_EXPORT_INTERVAL instead of OTEL_COLLECTION_INTERVAL env var

### DIFF
--- a/otel/CHANGELOG.md
+++ b/otel/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be released
 
+- fix: Remove `OTEL_COLLECTION_INTERVAL` env var in favor of [OTEL_METRIC_EXPORT_INTERVAL](https://github.com/open-telemetry/opentelemetry-go/blob/a9cbc3d8dec7be22c7d3691ca1755f25c1702a1d/sdk/metric/env.go#L17)
 - docs: Updated README.md and added examples with implemented code and unit tests
 - test: Add `oteltest` package that contains test helpers for unit testing
 - test: Add `otelmock` package that contains mocks required for unit testing

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -21,7 +21,7 @@ type Config struct {
 	Debug                bool          `default:"false"`
 	ExporterType         string        `default:"http" split_words:"true"`
 	ExporterOtlpEndpoint string        `default:"" split_words:"true"`
-	CollectionInterval   time.Duration `default:"10s" split_words:"true"`
+	MetricExportInterval time.Duration `default:"10s" split_words:"true"`
 }
 
 func Init(ctx context.Context) (func(context.Context) error, error) {
@@ -40,7 +40,10 @@ func Init(ctx context.Context) (func(context.Context) error, error) {
 		return nil, errors.Wrap(ctx, err, "load exporter")
 	}
 
-	metricsReader := sdkmetric.NewPeriodicReader(metricsExporter, sdkmetric.WithInterval(cfg.CollectionInterval))
+	metricsReader := sdkmetric.NewPeriodicReader(
+		metricsExporter,
+		sdkmetric.WithInterval(cfg.MetricExportInterval),
+	)
 
 	res, err := resource.Merge(
 		resource.Default(),


### PR DESCRIPTION
Fix #1091 

- [x] Add a changelog entry in `CHANGELOG.md`
