### PR TITLE
feat(otel): Add `OTEL_DEBUG_PRETTY_PRINT` env var to enable or disable pretty printing of OpenTelemetry payloads

### DIFF
--- a/otel/CHANGELOG.md
+++ b/otel/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be released
 
+- feat: Add `OTEL_DEBUG_PRETTY_PRINT` env var to enable or disable pretty printing of OpenTelemetry payloads (default: enabled)
 - fix: Remove `OTEL_COLLECTION_INTERVAL` env var in favor of [OTEL_METRIC_EXPORT_INTERVAL](https://github.com/open-telemetry/opentelemetry-go/blob/a9cbc3d8dec7be22c7d3691ca1755f25c1702a1d/sdk/metric/env.go#L17)
 - docs: Updated README.md and added examples with implemented code and unit tests
 - test: Add `oteltest` package that contains test helpers for unit testing

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -19,6 +19,7 @@ import (
 type Config struct {
 	ServiceName          string        `required:"true" split_words:"true"`
 	Debug                bool          `default:"false"`
+	DebugPrettyPrint     bool          `default:"true" split_words:"true"`
 	ExporterType         string        `default:"http" split_words:"true"`
 	ExporterOtlpEndpoint string        `default:"" split_words:"true"`
 	MetricExportInterval time.Duration `default:"10s" split_words:"true"`
@@ -75,7 +76,10 @@ func Init(ctx context.Context) (func(context.Context) error, error) {
 
 func newMetricsExporter(ctx context.Context, cfg Config) (sdkmetric.Exporter, error) {
 	if cfg.Debug {
-		return stdoutmetric.New(stdoutmetric.WithPrettyPrint())
+		if cfg.DebugPrettyPrint {
+			return stdoutmetric.New(stdoutmetric.WithPrettyPrint())
+		}
+		return stdoutmetric.New()
 	}
 	if cfg.ExporterOtlpEndpoint == "" {
 		return nil, errors.New(ctx, "otlp endpoint is required")


### PR DESCRIPTION
Fix #1113

- [x] Add a changelog entry in `CHANGELOG.md`
