### PR TITLE
fix(graceful): VULN Defer mutex unlock + lint

### DIFF
--- a/graceful/service.go
+++ b/graceful/service.go
@@ -77,6 +77,7 @@ func WithNumServers(n int) Option {
 func (s *Service) initTableflipUpgrader(ctx context.Context) error {
 	var err error
 	s.mx.Lock()
+	defer s.mx.Unlock()
 	if s.upg == nil {
 		s.upg, err = tableflip.New(tableflip.Options{
 			UpgradeTimeout: s.reloadWaitDuration,
@@ -86,7 +87,6 @@ func (s *Service) initTableflipUpgrader(ctx context.Context) error {
 			return errors.Wrap(ctx, err, "create tableflip upgrader")
 		}
 	}
-	s.mx.Unlock()
 	return nil
 }
 

--- a/graceful/service_test.go
+++ b/graceful/service_test.go
@@ -447,7 +447,6 @@ func (c *cmdAndOutput) stop() {
 	if c.pidFile != "" {
 		require.NoError(c.t, os.Remove(c.pidFile))
 	}
-
 }
 
 // isRunningAfter checks if the process is running after a certain duration

--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* fix(graceful): vulnerability defer mutex unlock
+
 ## v1.5.0
 
 * feat(logger): add close wrapper of rollbar plugin


### PR DESCRIPTION
This PR fixes issue #1122 identified by semgrep, where a mutex lock might not be released

- [x] Add a changelog entry in `CHANGELOG.md`
