### PR TITLE
fix(graceful/logger): revert erroneous changelog update

### DIFF
--- a/graceful/CHANGELOG.md
+++ b/graceful/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be released
 
+* fix: vulnerability defer mutex unlock
+
 ## v.1.2.0
 
 * feat: allow multiple http servers to be started with a single graceful service

--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## To be Released
 
-* fix(graceful): vulnerability defer mutex unlock
-
 ## v1.5.0
 
 * feat(logger): add close wrapper of rollbar plugin


### PR DESCRIPTION
This PR fixes an error merged in the PR #1123 where the incorrect changelog was updated.