### PR TITLE
[STORY-2085] Update Go version to 1.24.3

### DIFF
--- a/concurrency/go.mod
+++ b/concurrency/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/concurrency
 
-go 1.23.3
+go 1.24.3
 
 require github.com/Scalingo/go-utils/logger v1.5.0
 

--- a/cronsetup/go.mod
+++ b/cronsetup/go.mod
@@ -1,8 +1,6 @@
 module github.com/Scalingo/go-utils/cronsetup
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-etcd-cron v1.3.3

--- a/crypto/go.mod
+++ b/crypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/crypto
 
-go 1.20
+go 1.24.3
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/difflib/go.mod
+++ b/difflib/go.mod
@@ -1,3 +1,3 @@
 module github.com/Scalingo/go-utils/difflib
 
-go 1.20
+go 1.24.3

--- a/env/go.mod
+++ b/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/env
 
-go 1.20
+go 1.24.3
 
 require github.com/stretchr/testify v1.10.0
 

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/errors/v2
 
-go 1.20
+go 1.24.3
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/etcd/go.mod
+++ b/etcd/go.mod
@@ -1,8 +1,6 @@
 module github.com/Scalingo/go-utils/etcd
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.3
 
 require (
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/fs
 
-go 1.23.0
+go 1.24.3
 
 require github.com/spf13/afero v1.14.0
 

--- a/gomock_generator/go.mod
+++ b/gomock_generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/gomock_generator
 
-go 1.23.3
+go 1.24.3
 
 // In Dev you can uncomment the following line to use the local 'logger' package
 // replace github.com/Scalingo/go-utils/logger => ../logger

--- a/graceful/go.mod
+++ b/graceful/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/graceful
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0

--- a/httpclient/go.mod
+++ b/httpclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/httpclient
 
-go 1.20
+go 1.24.3
 
 require (
 	github.com/gofrs/uuid/v5 v5.3.2

--- a/influx/go.mod
+++ b/influx/go.mod
@@ -1,7 +1,6 @@
 module github.com/Scalingo/go-utils/influx
 
-go 1.22.5
-toolchain go1.24.1
+go 1.24.3
 
 require (
 	github.com/influxdata/influxdb v1.12.0

--- a/io/go.mod
+++ b/io/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/io
 
-go 1.23.0
+go 1.24.3
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -1,8 +1,6 @@
 module github.com/Scalingo/go-utils/logger
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.3
 
 require (
 	github.com/Scalingo/logrus-rollbar v1.4.2

--- a/mongo/go.mod
+++ b/mongo/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/mongo
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-handlers v1.8.2

--- a/nsqconsumer/go.mod
+++ b/nsqconsumer/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/nsqconsumer
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0

--- a/nsqlbproducer/go.mod
+++ b/nsqlbproducer/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/nsqlbproducer
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/env v1.1.1

--- a/nsqproducer/go.mod
+++ b/nsqproducer/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/nsqproducer
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/env v1.1.1

--- a/otel/docs/examples/int64-async-gauge/go.mod
+++ b/otel/docs/examples/int64-async-gauge/go.mod
@@ -1,8 +1,6 @@
 module github.com/Scalingo/go-utils/docs/examples/int64-async-gauge
 
-go 1.23.4
-
-toolchain go1.24.1
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/otel v0.1.1-0.20250228111151-d9135ac81a90

--- a/otel/docs/examples/int64-sync-counter/go.mod
+++ b/otel/docs/examples/int64-sync-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/docs/examples/int64-sync-counter
 
-go 1.23.4
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/otel v0.1.1-0.20250228111151-d9135ac81a90

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/otel
 
-go 1.23.4
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0

--- a/pagination/go.mod
+++ b/pagination/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/pagination
 
-go 1.22
+go 1.24.3
 
 require github.com/stretchr/testify v1.9.0
 

--- a/postgresql/go.mod
+++ b/postgresql/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/postgresql
 
-go 1.22
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0

--- a/publicgen/go.mod
+++ b/publicgen/go.mod
@@ -1,3 +1,3 @@
 module github.com/Scalingo/go-utils/publicgen
 
-go 1.20
+go 1.24.3

--- a/retry/go.mod
+++ b/retry/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/retry
 
-go 1.20
+go 1.24.3
 
 require github.com/stretchr/testify v1.10.0
 

--- a/security/go.mod
+++ b/security/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/security
 
-go 1.20
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/crypto v1.0.0

--- a/security/go.sum
+++ b/security/go.sum
@@ -9,6 +9,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/storage
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0

--- a/tarball/go.mod
+++ b/tarball/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-utils/tarball
 
-go 1.23.3
+go 1.24.3
 
 require (
 	github.com/Scalingo/go-utils/fs v1.0.2


### PR DESCRIPTION
This PR Update Go version of all modules to 1.24.3 in order to fix golangci-lint.