### PR TITLE
[STORY-2085] Missing any depth checking for go.sum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # This file defines who is responsible for code reviews in this repository
 
 # Go dependency files - assign to EtienneM for Dependabot PRs
-*/go.sum @EtienneM
+**/go.sum @EtienneM
 
 # GitHub Actions workflows
 .github/workflows/* @EtienneM


### PR DESCRIPTION
The reason for changing from */go.sum to **/go.sum is that we have go.sum files at different depth levels in our repository:

  - Most go.sum files are at depth 2 (e.g., ./logger/go.sum, ./crypto/go.sum)
  - But we also have go.sum files at depth 5 in the otel examples:
    - ./otel/docs/examples/int64-async-gauge/go.sum
    - ./otel/docs/examples/int64-sync-counter/go.sum