### PR TITLE
[concurrency] Bump v1.2.0

### DIFF
--- a/concurrency/CHANGELOG.md
+++ b/concurrency/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## To be Released
 
+## v1.2.0
+
+* chore(go): upgrade to Go 1.24
+
+
 * build(deps): bump github.com/Scalingo/go-utils/logger from 1.1.1 to 1.2.0
 
 ## v1.1.1

--- a/concurrency/README.md
+++ b/concurrency/README.md
@@ -1,4 +1,4 @@
-# Package `concurrency` v1.1.1
+# Package `concurrency` v1.2.0
 
 ## Parallel Worker
 


### PR DESCRIPTION
chore(go): upgrade to Go 1.24