### PR TITLE
[errors] Bump v2.5.0

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## To be Released
 
+## v2.5.0
+
+* chore(go): upgrade to Go 1.24
+
 ## v2.4.0
 
 * docs(errors): deprecate use of `errgo` in `ErrCtx`

--- a/errors/README.md
+++ b/errors/README.md
@@ -1,3 +1,3 @@
-# Package `errors` v2.4.0
+# Package `errors` v2.5.0
 
 The package `errors` contains various utility regarding errors management.


### PR DESCRIPTION
chore(go): upgrade to Go 1.24