### PR TITLE
[io] Bump v1.5.0

### DIFF
--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## To be Released
 
+## v1.5.0
+
+* chore(go): upgrade to Go 1.24
+
+## v1.4.0
+
+* chore(go): upgrade to Go 1.24
+
+## v1.3.0
+
+* chore(go): upgrade to Go 1.24
+
+## v1.2.0
+
+* chore(go): upgrade to Go 1.24
 * build(deps): bump github.com/stretchr/testify from 1.8.0 to 1.8.1
 
 ## v1.1.1

--- a/io/README.md
+++ b/io/README.md
@@ -1,4 +1,4 @@
-# Package `io` v1.1.1
+# Package `io` v1.5.0
 
 This package aims at proposing a customizable `io.Copy` method. It introduces the `Copier` struct.
 


### PR DESCRIPTION
chore(go): upgrade to Go 1.24