### PR TITLE
[nsqconsumer] Bump v1.8.0

### DIFF
--- a/nsqconsumer/CHANGELOG.md
+++ b/nsqconsumer/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## To be Released
 
+## v1.8.0
+
+* chore(go): upgrade to Go 1.24
+
+## v1.7.0
+
+* chore(go): upgrade to Go 1.24
+
+## v1.6.0
+
+* chore(go): upgrade to Go 1.24
+
+## v1.5.0
+
+* chore(go): upgrade to Go 1.24
+
 ## v1.4.1
 
 * fix(disable-backoff): fix configuration of consumer to correctly handle DisableBackoff argument

--- a/nsqconsumer/README.md
+++ b/nsqconsumer/README.md
@@ -1,1 +1,1 @@
-# Package `nsqconsumer` v1.4.1
+# Package `nsqconsumer` v1.8.0


### PR DESCRIPTION
chore(go): upgrade to Go 1.24