### PR TITLE
fix(errors): `Build` returns `error` not `*ValidationErrors`

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* fix(errors): `Build` returns `error` not `*ValidationErrors`
 * refactor(errors): remove deprecated functions (BREAKING CHANGE)
 
 ## v2.5.0

--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## To be Released
 
-* fix(errors): `Build` returns `error` not `*ValidationErrors`
+* fix(errors): `Build` returns `error` not `*ValidationErrors` (BREAKING CHANGE)
 * refactor(errors): remove deprecated functions (BREAKING CHANGE)
 
 ## v2.5.0

--- a/errors/validation_errors.go
+++ b/errors/validation_errors.go
@@ -88,8 +88,7 @@ func (v *ValidationErrorsBuilder) MergeWithPrefix(prefix string, verr *Validatio
 // Build will send a ValidationErrors struct if there is some errors or nil if no errors has been defined
 func (v *ValidationErrorsBuilder) Build() error {
 	if len(v.errors) == 0 {
-		var verr *ValidationErrors
-		return verr
+		return nil
 	}
 
 	return &ValidationErrors{

--- a/errors/validation_errors.go
+++ b/errors/validation_errors.go
@@ -26,6 +26,7 @@ func (v *ValidationErrors) Error() string {
 }
 
 // ValidationErrorsBuilder is used to provide a simple way to create a ValidationErrors struct. The typical usecase is:
+//
 //	func (m *MyModel) Validate(ctx context.Context) *ValidationErrors {
 //		validations := document.NewValidationErrorsBuilder()
 //
@@ -85,9 +86,10 @@ func (v *ValidationErrorsBuilder) MergeWithPrefix(prefix string, verr *Validatio
 }
 
 // Build will send a ValidationErrors struct if there is some errors or nil if no errors has been defined
-func (v *ValidationErrorsBuilder) Build() *ValidationErrors {
+func (v *ValidationErrorsBuilder) Build() error {
 	if len(v.errors) == 0 {
-		return nil
+		var verr *ValidationErrors
+		return verr
 	}
 
 	return &ValidationErrors{

--- a/errors/validation_errors_test.go
+++ b/errors/validation_errors_test.go
@@ -1,15 +1,17 @@
 package errors
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidationErrorsBuilder_Merge(t *testing.T) {
 	cases := map[string]struct {
 		Builder  *ValidationErrorsBuilder
-		Error    *ValidationErrors
+		Error    error
 		Expected *ValidationErrorsBuilder
 	}{
 		"merging nil is a no-op": {
@@ -26,7 +28,11 @@ func TestValidationErrorsBuilder_Merge(t *testing.T) {
 
 	for title, c := range cases {
 		t.Run(title, func(t *testing.T) {
-			require.Equal(t, c.Expected, c.Builder.Merge(c.Error))
+			var verr *ValidationErrors
+			require.True(t, errors.As(c.Error, &verr))
+
+			mergedError := c.Builder.Merge(verr)
+			assert.Equal(t, c.Expected, mergedError)
 		})
 	}
 }
@@ -34,7 +40,7 @@ func TestValidationErrorsBuilder_Merge(t *testing.T) {
 func TestValidationErrorsBuilder_MergeWithPrefix(t *testing.T) {
 	cases := map[string]struct {
 		Builder  *ValidationErrorsBuilder
-		Error    *ValidationErrors
+		Error    error
 		Expected *ValidationErrorsBuilder
 		Prefix   string
 	}{
@@ -59,7 +65,11 @@ func TestValidationErrorsBuilder_MergeWithPrefix(t *testing.T) {
 
 	for title, c := range cases {
 		t.Run(title, func(t *testing.T) {
-			require.Equal(t, c.Expected, c.Builder.MergeWithPrefix(c.Prefix, c.Error))
+			var verr *ValidationErrors
+			require.True(t, errors.As(c.Error, &verr))
+
+			mergedError := c.Builder.MergeWithPrefix(c.Prefix, verr)
+			require.Equal(t, c.Expected, mergedError)
 		})
 	}
 }


### PR DESCRIPTION
Fix #892

- [x] Add a changelog entry in `CHANGELOG.md`