### PR TITLE
refactor(errors): remove deprecated functions

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* refactor(errors): remove deprecated functions (BREAKING CHANGE)
+
 ## v2.5.0
 
 * chore(go): upgrade to Go 1.24

--- a/errors/cause.go
+++ b/errors/cause.go
@@ -2,7 +2,6 @@ package errors
 
 import (
 	"errors"
-	"reflect"
 
 	"gopkg.in/errgo.v1"
 )
@@ -35,35 +34,6 @@ func As(receivedErr error, expectedType any) bool {
 		}
 	}
 	return false
-}
-
-// RootCause returns the cause of an errors stack, whatever the method they used
-// to be stacked: either errgo.Notef or errors.Wrapf.
-//
-// Deprecated: Use `Is(err, expectedErr)` instead of `if RootCause(err) == expectedErr` to match go standard libraries practices
-func RootCause(err error) error {
-	errCause := errorCause(err)
-	if errCause == nil {
-		errCause = errgoRoot(err)
-	}
-	return errCause
-}
-
-// IsRootCause return true if the cause of the given error is the same type as
-// mytype.
-// This function takes the cause of an error if the errors stack has been
-// wrapped with errors.Wrapf or errgo.Notef or errgo.NoteMask or errgo.Mask.
-//
-// Example:
-//
-//	errors.IsRootCause(err, &ValidationErrors{})
-//
-// Deprecated: Use `As(err, mytype)` instead to match go standard libraries practices
-func IsRootCause(err error, mytype interface{}) bool {
-	t := reflect.TypeOf(mytype)
-	errCause := errorCause(err)
-	errRoot := errgoRoot(err)
-	return reflect.TypeOf(errCause) == t || reflect.TypeOf(errRoot) == t
 }
 
 // UnwrapError tries to unwrap `err`. It unwraps any causer type, errgo and ErrCtx errors.

--- a/errors/cause_test.go
+++ b/errors/cause_test.go
@@ -71,26 +71,6 @@ func Test_As(t *testing.T) {
 		assert.True(t, As(err, &expectedErrorType))
 		assert.False(t, As(err, &unexpectedErrorType))
 	})
-
-	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = Notef(context.Background(), err, "biniou")
-
-		assert.True(t, As(err, &expectedErrorType))
-		assert.False(t, As(err, &unexpectedErrorType))
-	})
-
-	t.Run("given an error in the middle of the stack stack with Notef from ErrCtx", func(t *testing.T) {
-		var err error
-		err = io.EOF
-		err = &customError{WrappedError: err, CustomValue: "value"}
-		err = Notef(context.Background(), err, "biniou")
-
-		var expectedErrorType *customError
-		assert.True(t, As(err, &expectedErrorType))
-		assert.False(t, As(err, &unexpectedErrorType))
-	})
 }
 
 func Test_Is(t *testing.T) {
@@ -131,142 +111,12 @@ func Test_Is(t *testing.T) {
 
 	t.Run("given an error stack with mixed types", func(t *testing.T) {
 		expectedError := io.EOF
-		err := Notef(context.Background(), expectedError, "pouet")
+
+		err := Wrapf(t.Context(), io.EOF, "pouet")
 		err = errgo.Notef(err, "pouet")
 		err = errors.Wrap(err, "pouet")
 
 		assert.True(t, Is(err, expectedError))
-	})
-}
-
-func Test_IsRootCause(t *testing.T) {
-	t.Run("given an error stack with errgo.Notef", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = errgo.Notef(err, "biniou")
-
-		assert.True(t, IsRootCause(err, &ValidationErrors{}))
-		assert.False(t, IsRootCause(err, ValidationErrors{}))
-	})
-
-	t.Run("given an error stack with errors.Wrap", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = errors.Wrap(err, "biniou")
-
-		assert.True(t, IsRootCause(err, &ValidationErrors{}))
-		assert.False(t, IsRootCause(err, ValidationErrors{}))
-	})
-
-	t.Run("given an error stack with errors.Wrapf", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = errors.Wrapf(err, "biniou")
-
-		assert.True(t, IsRootCause(err, &ValidationErrors{}))
-		assert.False(t, IsRootCause(err, ValidationErrors{}))
-	})
-
-	t.Run("given an error stack with Wrap from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = Wrap(context.Background(), err, "biniou")
-
-		assert.True(t, IsRootCause(err, &ValidationErrors{}))
-		assert.False(t, IsRootCause(err, ValidationErrors{}))
-	})
-
-	t.Run("given an error stack with Wrapf from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = Wrapf(context.Background(), err, "biniou")
-
-		assert.True(t, IsRootCause(err, &ValidationErrors{}))
-		assert.False(t, IsRootCause(err, ValidationErrors{}))
-	})
-
-	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{})
-		err = Notef(context.Background(), err, "biniou")
-
-		assert.True(t, IsRootCause(err, &ValidationErrors{}))
-		assert.False(t, IsRootCause(err, ValidationErrors{}))
-	})
-
-}
-
-func Test_RootCause(t *testing.T) {
-	t.Run("given an error stack with errgo.Mask", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = errgo.Mask(err, errgo.Any)
-
-		assert.Equal(t, "test=biniou", RootCause(err).Error())
-	})
-
-	t.Run("given an error stack with errgo.Notef", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = errgo.Notef(err, "pouet")
-
-		assert.Equal(t, "test=biniou", RootCause(err).Error())
-	})
-
-	t.Run("given an error stack with errors.Wrap", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = errors.Wrap(err, "pouet")
-
-		assert.Equal(t, "test=biniou", RootCause(err).Error())
-	})
-
-	t.Run("given an error stack with Wrap from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = Wrap(context.Background(), err, "pouet")
-
-		assert.Equal(t, "test=biniou", RootCause(err).Error())
-	})
-
-	t.Run("given an error stack with Wrapf from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = Wrapf(context.Background(), err, "pouet")
-
-		assert.Equal(t, "test=biniou", RootCause(err).Error())
-	})
-
-	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = Notef(context.Background(), err, "pouet")
-
-		assert.Equal(t, "test=biniou", RootCause(err).Error())
 	})
 }
 
@@ -304,18 +154,7 @@ func Test_UnwrapError(t *testing.T) {
 		assert.Equal(t, "test=biniou", lastErr.Error())
 	})
 
-	t.Run("given an error stack with Notef from ErrCtx", func(t *testing.T) {
-		var err error
-		err = (&ValidationErrors{
-			Errors: map[string][]string{
-				"test": {"biniou"},
-			},
-		})
-		err = Notef(context.Background(), err, "pouet")
-
-		assert.Equal(t, "pouet: test=biniou", UnwrapError(err).Error())
-	})
-	t.Run("given an error nil", func(t *testing.T) {
+	t.Run("given a nil error", func(t *testing.T) {
 		var err error
 		assert.Nil(t, UnwrapError(err))
 	})

--- a/errors/errctx.go
+++ b/errors/errctx.go
@@ -33,11 +33,6 @@ func Newf(ctx context.Context, format string, args ...interface{}) error {
 	return Errorf(ctx, format, args...)
 }
 
-// Deprecated: Use `Wrap` or `Wrapf` instead of `Notef`. The library is able to unwrap mixed errors (wrapped with `errgo` or `github.com/pkg/errors`).
-func Notef(ctx context.Context, err error, format string, args ...interface{}) error {
-	return ErrCtx{ctx: ctx, err: errgo.Notef(err, format, args...)}
-}
-
 func Wrap(ctx context.Context, err error, message string) error {
 	return ErrCtx{ctx: ctx, err: errors.Wrap(err, message)}
 }

--- a/errors/errctx_test.go
+++ b/errors/errctx_test.go
@@ -32,9 +32,9 @@ func TestErrCtx_RootCtxOrFallback(t *testing.T) {
 		// Given
 		ctx := context.WithValue(context.Background(), "field0", "value0")
 		err := funcThrowingError(ctx)
-		err = Notef(ctx, err, "wrapping error in func2")
-		err = Notef(ctx, err, "wrapping error in func3")
-		err = Notef(ctx, err, "wrapping error in func4")
+		err = Wrapf(ctx, err, "wrapping error in func2")
+		err = Wrapf(ctx, err, "wrapping error in func3")
+		err = Wrapf(ctx, err, "wrapping error in func4")
 
 		// When
 		rootCtx := RootCtxOrFallback(ctx, err)
@@ -53,8 +53,8 @@ func TestErrCtx_RootCtxOrFallback(t *testing.T) {
 		// Given
 		ctx := context.WithValue(context.Background(), "field0", "value0")
 		err := funcWrappingAnError(ctx)
-		err = Notef(ctx, err, "wrapping error in func3")
-		err = Notef(ctx, err, "wrapping error in func4")
+		err = Wrapf(ctx, err, "wrapping error in func3")
+		err = Wrapf(ctx, err, "wrapping error in func4")
 
 		// When
 		rootCtx := RootCtxOrFallback(ctx, err)
@@ -74,8 +74,8 @@ func TestErrCtx_RootCtxOrFallback(t *testing.T) {
 		ctx := context.WithValue(context.Background(), "field0", "value0")
 		// Simulate non ErrCtx error in middle of error path
 		err := funcWrappingAnErrorWithoutErrCtx(ctx)
-		err = Notef(ctx, err, "wrapping error in func2")
-		err = Notef(ctx, err, "wrapping error in func3")
+		err = Wrapf(ctx, err, "wrapping error in func2")
+		err = Wrapf(ctx, err, "wrapping error in func3")
 
 		// When
 		rootCtx := RootCtxOrFallback(ctx, err)
@@ -101,9 +101,9 @@ func TestErrCtx_RootCtxOrFallback(t *testing.T) {
 		// Simulate non returning error
 		ctx = context.WithValue(ctx, "field2", "value2")
 		err = Newf(ctx, "new error from func2")
-		err = Notef(ctx, err, "wrapping error in func2")
-		err = Notef(ctx, err, "wrapping error in func3")
-		err = Notef(ctx, err, "wrapping error in func4")
+		err = Wrapf(ctx, err, "wrapping error in func2")
+		err = Wrapf(ctx, err, "wrapping error in func3")
+		err = Wrapf(ctx, err, "wrapping error in func4")
 
 		// When
 		rootCtx := RootCtxOrFallback(ctx, err)
@@ -133,7 +133,7 @@ func funcWrappingAnError(ctx context.Context) error {
 
 	err := funcThrowingError(ctx)
 	if err != nil {
-		return Notef(ctx, err, "wrapping error from funcWrappingAnError")
+		return Wrapf(ctx, err, "wrapping error from funcWrappingAnError")
 	}
 	return nil
 }


### PR DESCRIPTION
The PR #1207 introduces a breaking change, which leads to a new major version. This is a perfect time to remove the deprecated methods we have in this library.

- [x] Add a changelog entry in `CHANGELOG.md`