### PR TITLE
fix(dependabot): Add missing modules to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,17 @@ updates:
           - "*"
 
   - package-ecosystem: "gomod"
+    directory: "/crypto"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
     directory: "/difflib"
     allow:
       - dependency-type: "all"
@@ -188,6 +199,39 @@ updates:
           - "*"
 
   - package-ecosystem: "gomod"
+    directory: "/otel"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/pagination"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/postgresql"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
     directory: "/publicgen"
     allow:
       - dependency-type: "all"
@@ -200,6 +244,17 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/retry"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/security"
     allow:
       - dependency-type: "all"
     schedule:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This repository is hosting modules, each of these modules are independant, they 
 * `CHANGELOG.md`
 * Versioning through git tags. (Example for `etcd` → tag will look like `etcd/v1.0.0`)
 
+## Adding a New Module
+
+- Follow the defined structure above
+- Add the module on the dependabot config located in `.github` directory
+
 ## Release a New Version of a Module
 
 Bump new version number in:


### PR DESCRIPTION
Fix #1234

Some modules like `otel` and other ones was not tracked in the dependabot config. I added it