### PR TITLE
build(dependabot): ignore `github.com/aws/aws-sdk-go-v2` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -219,6 +219,12 @@ updates:
       dependencies:
         patterns:
           - "*"
+    # Ignore AWS SDK updates due to
+    # https://github.com/Scalingo/go-utils/issues/1231
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2"
+        versions: [">=1.32.8"]
+
 
   - package-ecosystem: "gomod"
     directory: "/tarball"


### PR DESCRIPTION
Ignore `github.com/aws/aws-sdk-go-v2` updates waiting for https://github.com/Scalingo/go-utils/issues/1231

Not applicable:
- [ ] Add a changelog entry in `CHANGELOG.md`