### PR TITLE
build(codeowners): for `.github/*` rather than `.github/workflows/*` which does not exist in this repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 */go.sum @EtienneM
 
 # GitHub Actions workflows
-.github/workflows/* @EtienneM
+.github/* @EtienneM


### PR DESCRIPTION
I wonder whether the issue reported by @brandon-welsch  [here](https://scalingo.slack.com/archives/C01PFD3GBU7/p1752591610697449) is not because of this. That's what I understand from the error reported on this page: https://github.com/Scalingo/go-utils/network/updates/15269090/jobs

- [ ] Add a changelog entry in `CHANGELOG.md`