### PR TITLE
build(dependabot): ignore `github.com/aws/aws-sdk-go-v2` without version specified

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -223,7 +223,6 @@ updates:
     # https://github.com/Scalingo/go-utils/issues/1231
     ignore:
       - dependency-name: "github.com/aws/aws-sdk-go-v2"
-        versions: [">=1.32.8"]
 
 
   - package-ecosystem: "gomod"


### PR DESCRIPTION
We try to configure Dependabot to ignore this Dependency. For some reason, the previous configuration (#1236) didn't work (#1251). Let's try to configure this without specifying the version to see if it works...

- [ ] Add a changelog entry in `CHANGELOG.md`