### PR TITLE
chore: retract version 1.9.0

### DIFF
--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* chore: retract version 1.9.0. It had accidentally been released rather than a lower version (1.6.0). Hence we retract it and release a new version 1.9.1.
+
 ## v1.6.1
 
 * chore(go): corrective bump - Go version regression from 1.24.3 to 1.24

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -18,3 +18,5 @@ require (
 	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract v1.9.0 // Had accidentally been released rather than a lower version (1.6.0). Hence we retract it and release a new version 1.9.1.


### PR DESCRIPTION
Despite the Git tag having been removed, Dependabot keeps suggesting this version (e.g. #1247). This is because this version is recorded in `pkg.go.dev` cache (https://pkg.go.dev/github.com/Scalingo/go-utils/logger@v1.9.0). The only solution from what we understand is to retract the faulty version.

After this PR, we will release version 1.9.1.

We discussed this on Slack: https://scalingo.slack.com/archives/C01E42AT2G6/p1752732381310239

- [x] Add a changelog entry in `CHANGELOG.md`