### PR TITLE
build(deps): Bump github.com/Scalingo/go-utils/errors from v2.5.1 to v3.0.0

### DIFF
--- a/otel/CHANGELOG.md
+++ b/otel/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be released
 
+* build: Bump github.com/Scalingo/go-utils/errors from v2.5.1 to v3.0.0
+
 ## v0.6.1
 
 * fix: Correctly load TLS certificates again from env vars since it broke in v0.6.0

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/Scalingo/go-utils/otel
 go 1.24
 
 require (
-	github.com/Scalingo/go-utils/errors/v2 v2.5.1
+	github.com/Scalingo/go-utils/errors/v3 v3.0.0
 	github.com/Scalingo/go-utils/logger v1.9.1
 	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/golang/mock v1.6.0

--- a/otel/go.sum
+++ b/otel/go.sum
@@ -1,5 +1,5 @@
-github.com/Scalingo/go-utils/errors/v2 v2.5.1 h1:1tfJW6/ZxTgrRmFTlKQCOtArQquOW0/XdZQzx8wMHoM=
-github.com/Scalingo/go-utils/errors/v2 v2.5.1/go.mod h1:SbR1JuMtfAl+gpM7ahUW/c3Jm5MMzMAwJBk1pEHkVd8=
+github.com/Scalingo/go-utils/errors/v3 v3.0.0 h1:ss54AOJDR8LU3tjSA1Gf320ikY0WkgGsm7reeGYt7p0=
+github.com/Scalingo/go-utils/errors/v3 v3.0.0/go.mod h1:+yY6dLBGI7N7gv7FHDO2iq0nYjkD3U4j7riko/a/y6Q=
 github.com/Scalingo/go-utils/logger v1.9.1 h1:AjVCdWcIAQXzrrFdLTJVBhrAqMX27mSgXcUK53PSKQs=
 github.com/Scalingo/go-utils/logger v1.9.1/go.mod h1:A6oLYDkLaYaTAx1JJBBASYEwyEpayCfeAsnAdK0+TQw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/Scalingo/go-utils/errors/v2"
+	"github.com/Scalingo/go-utils/errors/v3"
 	"github.com/Scalingo/go-utils/logger"
 )
 


### PR DESCRIPTION
Fix #1289 

- [x] Add a changelog entry in `CHANGELOG.md`
