### PR TITLE
feat(errors/errctx) RootCtxOrFallback is now retro compatible

### DIFF
--- a/errors/CHANGELOG.md
+++ b/errors/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* feat(errctx) RootCtxOrFallback is now compatible with different versions of errors package.
+
 ## v.3.1.0
 
 * feat(UnwrapError) `UnwrapError` now unwraps errors which implement an `Unwrap()` method.


### PR DESCRIPTION
After `UnwrapError` (essentially used by nsqconsumer), here the update of `RootCtxOrFallback` that is used by go-handlers.


- [x] Add a changelog entry in `CHANGELOG.md`