### PR TITLE
feat(cronsetup): add option to provide etcd client

### DIFF
--- a/cronsetup/CHANGELOG.md
+++ b/cronsetup/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* feat(cronsetup): add option to provide etcd client
 * refactor(cronsetup): replace `github.com/Scalingo/go-etcd-cron` with `cronsetup/internal/cron`
 
 ## v1.3.0


### PR DESCRIPTION
`NewEtcdMutexBuilderFromClient` was added in go-etcd-cron a few weeks ago (https://github.com/Scalingo/go-etcd-cron/pull/113). We want to be able to use this in `cronsetup`.

- [x] Add a changelog entry in `CHANGELOG.md`