### PR TITLE
feat(document): `Validate` returns an `error`

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## To be Released
 
+* feat(document): `Validate` returns an `error` [BREAKING CHANGE]
+* feat(document): remove unused `ValidateWithInternalError` [BREAKING CHANGE]
+
 ## v1.5.3
 
 * build(deps): update `github.com/Scalingo/go-utils/errors` from v2 to v3

--- a/mongo/document/base.go
+++ b/mongo/document/base.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
-
-	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 type Base struct {
@@ -51,6 +49,6 @@ func (d *Base) destroy(ctx context.Context, collection string) error {
 	return ReallyDestroy(ctx, collection, d)
 }
 
-func (d *Base) Validate(_ context.Context) *errors.ValidationErrors {
+func (d *Base) Validate(_ context.Context) error {
 	return nil
 }

--- a/mongo/document/base.go
+++ b/mongo/document/base.go
@@ -54,7 +54,3 @@ func (d *Base) destroy(ctx context.Context, collection string) error {
 func (d *Base) Validate(_ context.Context) *errors.ValidationErrors {
 	return nil
 }
-
-func (d *Base) ValidateWithInternalError(_ context.Context) (*errors.ValidationErrors, error) {
-	return nil, ErrValidateNoInternalErrorFunc
-}

--- a/mongo/document/document.go
+++ b/mongo/document/document.go
@@ -47,7 +47,7 @@ type Closer interface {
 
 type Validable interface {
 	// Validate checks whether the document can be persisted.
-	Validate(ctx context.Context) *errors.ValidationErrors
+	Validate(ctx context.Context) error
 }
 
 var _ Validable = &Base{}

--- a/mongo/document/document.go
+++ b/mongo/document/document.go
@@ -2,7 +2,6 @@ package document
 
 import (
 	"context"
-	stderrors "errors"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -46,18 +45,9 @@ type Closer interface {
 	Close()
 }
 
-var ErrValidateNoInternalErrorFunc = stderrors.New("no validation returning an internal error has been implemented")
-
 type Validable interface {
-	// Validate will be used if no ValidateWithInternalError is defined on a document
-	// It is not useful to have both defined on a document, only ValidationWithInternalError
-	// would be used in this case
+	// Validate checks whether the document can be persisted.
 	Validate(ctx context.Context) *errors.ValidationErrors
-
-	// ValidateWithInternalError will be used in priority if defined on a document
-	// It will be called for all modifying operations (Create, Save, Update)
-	// If it returns an internal error, the validation error will be nil.
-	ValidateWithInternalError(ctx context.Context) (*errors.ValidationErrors, error)
 }
 
 var _ Validable = &Base{}
@@ -107,12 +97,7 @@ func Update(ctx context.Context, collectionName string, update bson.M, doc docum
 }
 
 func save(ctx context.Context, collectionName string, doc document, saveFunc func(context.Context, string, document) error) error {
-	validationErrors, err := doc.ValidateWithInternalError(ctx)
-	if errors.Is(err, ErrValidateNoInternalErrorFunc) {
-		validationErrors = doc.Validate(ctx)
-	} else if err != nil {
-		return errors.Wrap(ctx, err, "validate document")
-	}
+	validationErrors := doc.Validate(ctx)
 	if validationErrors != nil {
 		return validationErrors
 	}

--- a/mongo/document/document.go
+++ b/mongo/document/document.go
@@ -108,7 +108,7 @@ func Update(ctx context.Context, collectionName string, update bson.M, doc docum
 
 func save(ctx context.Context, collectionName string, doc document, saveFunc func(context.Context, string, document) error) error {
 	validationErrors, err := doc.ValidateWithInternalError(ctx)
-	if err == ErrValidateNoInternalErrorFunc {
+	if errors.Is(err, ErrValidateNoInternalErrorFunc) {
 		validationErrors = doc.Validate(ctx)
 	} else if err != nil {
 		return errors.Wrap(ctx, err, "validate document")

--- a/mongo/document/document_test.go
+++ b/mongo/document/document_test.go
@@ -24,16 +24,12 @@ type validatedDocument struct {
 	Valid bool `bson:"valid" json:"valid"`
 }
 
-func (d *validatedDocument) Validate(_ context.Context) *errors.ValidationErrors {
+func (d *validatedDocument) Validate(_ context.Context) error {
 	verr := errors.NewValidationErrorsBuilder()
 	if !d.Valid {
 		verr.Set("valid", "must be true")
 	}
-	err, ok := verr.Build().(*errors.ValidationErrors)
-	if !ok && err != nil {
-		panic("it must be a ValidationErrors")
-	}
-	return err
+	return verr.Build()
 }
 
 func buildValidatedDocument(valid bool) *validatedDocument {

--- a/mongo/document/document_test.go
+++ b/mongo/document/document_test.go
@@ -31,8 +31,7 @@ func (d *validatedDocument) Validate(_ context.Context) *errors.ValidationErrors
 	}
 	err, ok := verr.Build().(*errors.ValidationErrors)
 	if !ok && err != nil {
-		// If there is an error, it must have the type *errors.ValidationErrors
-		panic("invalid error type")
+		panic("it must be a ValidationErrors")
 	}
 	return err
 }
@@ -40,25 +39,6 @@ func (d *validatedDocument) Validate(_ context.Context) *errors.ValidationErrors
 func buildValidatedDocument(valid bool) *validatedDocument {
 	return &validatedDocument{
 		Valid: valid,
-	}
-}
-
-type validatedWithInternalErrorDocument struct {
-	validatedDocument `bson:",inline"`
-	InternalError     string `bson:"internal_error" json:"internal_error"`
-}
-
-func (d *validatedWithInternalErrorDocument) ValidateWithInternalError(ctx context.Context) (*errors.ValidationErrors, error) {
-	if d.InternalError != "" {
-		return nil, errors.New(ctx, d.InternalError)
-	}
-	return d.validatedDocument.Validate(ctx), nil
-}
-
-func buildValidatedWithInternalErrorDocument(valid bool, internalError string) *validatedWithInternalErrorDocument {
-	return &validatedWithInternalErrorDocument{
-		validatedDocument: *buildValidatedDocument(valid),
-		InternalError:     internalError,
 	}
 }
 
@@ -96,42 +76,6 @@ func TestDocument_Create(t *testing.T) {
 			err := Create(context.Background(), testDocuments, d)
 			require.Error(t, err)
 			require.IsType(t, &errors.ValidationErrors{}, err)
-			assert.Empty(t, d.ID)
-			assert.Empty(t, d.CreatedAt)
-		})
-	})
-
-	t.Run("with internal error validation", func(t *testing.T) {
-		t.Run("with a valid document, it should create it", func(t *testing.T) {
-			d := buildValidatedWithInternalErrorDocument(true, "")
-			err := Create(context.Background(), testDocuments, d)
-			require.NoError(t, err)
-			assert.NotEmpty(t, d.ID)
-			assert.NotEmpty(t, d.CreatedAt)
-		})
-		t.Run("with an invalid document, it should return a validation error", func(t *testing.T) {
-			d := buildValidatedWithInternalErrorDocument(false, "")
-			err := Create(context.Background(), testDocuments, d)
-			require.Error(t, err)
-			require.IsType(t, &errors.ValidationErrors{}, err)
-			assert.Empty(t, d.ID)
-			assert.Empty(t, d.CreatedAt)
-		})
-
-		t.Run("with a validation returning an internal error, it should forward internal error", func(t *testing.T) {
-			d := buildValidatedWithInternalErrorDocument(true, "internal error when validating")
-			err := Create(context.Background(), testDocuments, d)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "internal error when validating")
-			assert.Empty(t, d.ID)
-			assert.Empty(t, d.CreatedAt)
-		})
-
-		t.Run("with a validation returning an internal error and a validation error, it should return the internal error", func(t *testing.T) {
-			d := buildValidatedWithInternalErrorDocument(false, "internal error when validating")
-			err := Create(context.Background(), testDocuments, d)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "internal error when validating")
 			assert.Empty(t, d.ID)
 			assert.Empty(t, d.CreatedAt)
 		})


### PR DESCRIPTION

The upgrade from `Scalingo/go-utils/errors/v2` to `Scalingo/go-utils/errors/v3` in #1458 had a side effect. Now that the `ValidationErrorsBuilder` returns an `error` rather than a `*errors.ValidationErrors`, the `Validate` function in this library should also return an `error` or we end up with ugly cast in the `Validate` function we have here and there. I added a commit to highlight this problem here: https://github.com/Scalingo/scalingo-alerter-service/pull/246/changes/09759cc37c1ff0347a5ea27cc37fff3830fe70d5.

I added commit https://github.com/Scalingo/scalingo-alerter-service/pull/246/changes/5d10ed8b06526ea78266d8c1e4f12e1ec36c2d7f to highlight how better is the code with this new `Validate` signature.

Calling code can still get the `*errors.ValidationErrors` out of a call to `Validate` thanks to `errors.As`.


In this PR I am also removing `ValidateWithInternalError` because I didn't want to update this function signature. I find this useless. The proof that it's useless is that it's not used at all in the Scalingo codebase :D With this new signature, `Validate` can return an error that has a different type than `*errors.ValidationErrors` to point out an "internal" error, whatever this means.


- [x] Add a changelog entry in `CHANGELOG.md`