### PR TITLE
fix(nsq*producer): missing error wrapping

### DIFF
--- a/nsqlbproducer/CHANGELOG.md
+++ b/nsqlbproducer/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To be Released
 
 * fix(nsqlbproducer): correctly declare the v2
+* fix(nsqlbproducer): missing error wrapping
 
 ## v2.0.0
 

--- a/nsqlbproducer/env.go
+++ b/nsqlbproducer/env.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Scalingo/go-utils/env"
+	"github.com/Scalingo/go-utils/errors/v3"
 	"github.com/Scalingo/go-utils/nsqproducer"
 )
 
@@ -38,14 +39,19 @@ func FromEnv(ctx context.Context, opts FromEnvOpts) (*NsqLBProducer, error) {
 
 	nsqConfig, err := nsqproducer.NsqConfigFromEnv(E)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ctx, err, "get NSQ config from environment")
 	}
 
-	return New(ctx, LBProducerOpts{
+	nsqLBProducer, err := New(ctx, LBProducerOpts{
 		Hosts:      hosts,
 		NsqConfig:  nsqConfig,
 		Strategy:   StrategiesFromName[E["NSQ_PRODUCER_STRATEGY"]],
 		SkipLogSet: opts.SkipLogSet,
 		Logger:     opts.Logger,
 	})
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, "instantiate new NSQ LB producer")
+	}
+
+	return nsqLBProducer, nil
 }

--- a/nsqlbproducer/lbproducer.go
+++ b/nsqlbproducer/lbproducer.go
@@ -76,7 +76,7 @@ var _ nsqproducer.Producer = &NsqLBProducer{} // Ensure that NsqLBProducer imple
 
 func New(ctx context.Context, opts LBProducerOpts) (*NsqLBProducer, error) {
 	if len(opts.Hosts) == 0 {
-		return nil, fmt.Errorf("A producer must have at least one host")
+		return nil, errors.New(ctx, "a producer must have at least one host")
 	}
 	lbproducer := &NsqLBProducer{
 		producers: make([]producer, len(opts.Hosts)),

--- a/nsqproducer/CHANGELOG.md
+++ b/nsqproducer/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To be Released
 
 * fix(nsqproducer): correctly declare the v2
+* fix(nsqproducer): missing error wrapping
 
 ## v2.0.0
 

--- a/nsqproducer/env.go
+++ b/nsqproducer/env.go
@@ -27,15 +27,20 @@ func FromEnv(ctx context.Context) (*NsqProducer, error) {
 
 	nsqConfig, err := NsqConfigFromEnv(ctx, envMap)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ctx, err, "get NSQ config from environment")
 	}
 
-	return New(ProducerOpts{
+	nsqProducer, err := New(ProducerOpts{
 		Host: envMap["NSQD_HOST"],
 		Port: envMap["NSQD_PORT"],
 
 		NsqConfig: nsqConfig,
 	})
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, "instantiate new NSQ producer")
+	}
+
+	return nsqProducer, nil
 }
 
 func NsqConfigFromEnv(ctx context.Context, envMap map[string]string) (*nsq.Config, error) {


### PR DESCRIPTION
- [x] Add a changelog entry in `CHANGELOG.md`

I struggled investigating an issue internally with errors not being correctly wrapped. I went through these two packages and wrapped the errors.