### PR TITLE
fix(cronsetup): skip missed cron occurrences

### DIFF
--- a/cronsetup/internal/cron/cron.go
+++ b/cronsetup/internal/cron/cron.go
@@ -275,16 +275,7 @@ func (c *Cron) run(ctx context.Context) {
 
 		select {
 		case now = <-time.After(effective.Sub(now)):
-			// Run every entry whose next time was this effective time.
-			for _, e := range c.entries {
-				if e.Next != effective {
-					break
-				}
-				e.Prev = e.Next
-				e.Next = e.Schedule.Next(effective)
-
-				go c.runEntry(ctx, effective, e)
-			}
+			c.runEntries(ctx, effective, now)
 			continue
 
 		case newEntry := <-c.add:
@@ -300,6 +291,19 @@ func (c *Cron) run(ctx context.Context) {
 
 		// 'now' should be updated after newEntry and snapshot cases.
 		now = time.Now().Local()
+	}
+}
+
+func (c *Cron) runEntries(ctx context.Context, effective, now time.Time) {
+	// Run each due entry once and skip any occurrences missed while the scheduler was paused.
+	for _, e := range c.entries {
+		if e.Next != effective {
+			break
+		}
+		e.Prev = e.Next
+		e.Next = e.Schedule.Next(now)
+
+		go c.runEntry(ctx, effective, e)
 	}
 }
 

--- a/cronsetup/internal/cron/cron.go
+++ b/cronsetup/internal/cron/cron.go
@@ -26,6 +26,8 @@ type Cron struct {
 	funcCtx           func(context.Context, Job) context.Context
 	running           bool
 	etcdMutexBuilder  EtcdMutexBuilder
+	timeNow           func() time.Time
+	timeAfter         func(time.Duration) <-chan time.Time
 }
 
 // Job contains 3 mandatory options to define a job
@@ -184,11 +186,13 @@ func WithFuncCtx(f func(context.Context, Job) context.Context) Opt {
 // New returns a new cron job runner.
 func New(opts ...Opt) (*Cron, error) {
 	cron := &Cron{
-		entries:  nil,
-		add:      make(chan *Entry),
-		stop:     make(chan struct{}),
-		snapshot: make(chan []*Entry),
-		running:  false,
+		entries:   nil,
+		add:       make(chan *Entry),
+		stop:      make(chan struct{}),
+		snapshot:  make(chan []*Entry),
+		running:   false,
+		timeNow:   func() time.Time { return time.Now().Local() },
+		timeAfter: time.After,
 	}
 	for _, opt := range opts {
 		opt(cron)
@@ -255,7 +259,7 @@ func (c *Cron) Start(ctx context.Context) {
 // access to the 'running' state variable.
 func (c *Cron) run(ctx context.Context) {
 	// Figure out the next activation times for each entry.
-	now := time.Now().Local()
+	now := c.timeNow()
 	for _, entry := range c.entries {
 		entry.Next = entry.Schedule.Next(now)
 	}
@@ -274,7 +278,9 @@ func (c *Cron) run(ctx context.Context) {
 		}
 
 		select {
-		case now = <-time.After(effective.Sub(now)):
+		case <-c.timeAfter(effective.Sub(now)):
+			// A timer reports its scheduled expiration time, which may be stale when delivery is delayed.
+			now = c.timeNow()
 			c.runEntries(ctx, effective, now)
 			continue
 
@@ -290,7 +296,7 @@ func (c *Cron) run(ctx context.Context) {
 		}
 
 		// 'now' should be updated after newEntry and snapshot cases.
-		now = time.Now().Local()
+		now = c.timeNow()
 	}
 }
 

--- a/cronsetup/internal/cron/cron_test.go
+++ b/cronsetup/internal/cron/cron_test.go
@@ -355,9 +355,11 @@ func TestRunEntriesSkipsMissedOccurrences(t *testing.T) {
 			t.Fatal("unexpected error")
 		}
 
-		run := make(chan struct{}, 1)
+		dueRun := make(chan struct{}, 1)
+		futureRun := make(chan struct{}, 1)
 		effective := time.Date(2026, time.August, 14, 6, 0, 0, 0, time.UTC)
 		now := effective.Add(time.Hour)
+		future := effective.Add(2 * time.Hour)
 		cron.entries = []*Entry{
 			{
 				Schedule: Every(time.Minute),
@@ -365,7 +367,18 @@ func TestRunEntriesSkipsMissedOccurrences(t *testing.T) {
 				Job: Job{
 					Name: "test-skip-missed-occurrences",
 					Func: func(context.Context) error {
-						run <- struct{}{}
+						dueRun <- struct{}{}
+						return nil
+					},
+				},
+			},
+			{
+				Schedule: Every(time.Minute),
+				Next:     future,
+				Job: Job{
+					Name: "test-future-occurrence",
+					Func: func(context.Context) error {
+						futureRun <- struct{}{}
 						return nil
 					},
 				},
@@ -376,9 +389,14 @@ func TestRunEntriesSkipsMissedOccurrences(t *testing.T) {
 		synctest.Wait()
 
 		select {
-		case <-run:
+		case <-dueRun:
 		default:
 			t.Fatal("expected the due job to run")
+		}
+		select {
+		case <-futureRun:
+			t.Fatal("expected the future job not to run")
+		default:
 		}
 
 		entry := cron.entries[0]
@@ -388,6 +406,71 @@ func TestRunEntriesSkipsMissedOccurrences(t *testing.T) {
 		wantNext := now.Add(time.Minute)
 		if entry.Next != wantNext {
 			t.Errorf("next run = %s, want %s", entry.Next, wantNext)
+		}
+
+		futureEntry := cron.entries[1]
+		if !futureEntry.Prev.IsZero() {
+			t.Errorf("future job previous run = %s, want zero time", futureEntry.Prev)
+		}
+		if futureEntry.Next != future {
+			t.Errorf("future job next run = %s, want %s", futureEntry.Next, future)
+		}
+	})
+}
+
+func TestRunRefreshesCurrentTimeAfterDelayedTimer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cron, err := New()
+		if err != nil {
+			t.Fatal("unexpected error")
+		}
+
+		initial := time.Date(2026, time.August, 14, 6, 0, 0, 0, time.UTC)
+		effective := initial.Add(time.Minute)
+		current := initial
+		timer := make(chan time.Time)
+		waits := make(chan time.Duration, 2)
+		run := make(chan struct{}, 1)
+
+		cron.timeNow = func() time.Time {
+			return current
+		}
+		cron.timeAfter = func(delay time.Duration) <-chan time.Time {
+			waits <- delay
+			return timer
+		}
+		cron.Schedule(Every(time.Minute), Job{
+			Name: "test-refresh-current-time",
+			Func: func(context.Context) error {
+				run <- struct{}{}
+				return nil
+			},
+		})
+
+		cron.Start(t.Context())
+		defer cron.Stop()
+
+		if delay := <-waits; delay != time.Minute {
+			t.Fatalf("initial timer delay = %s, want %s", delay, time.Minute)
+		}
+
+		current = effective.Add(time.Hour)
+		timer <- effective
+		synctest.Wait()
+
+		select {
+		case <-run:
+		default:
+			t.Fatal("expected the due job to run")
+		}
+
+		entry := cron.entries[0]
+		wantNext := current.Add(time.Minute)
+		if entry.Next != wantNext {
+			t.Errorf("next run = %s, want %s", entry.Next, wantNext)
+		}
+		if delay := <-waits; delay != time.Minute {
+			t.Errorf("next timer delay = %s, want %s", delay, time.Minute)
 		}
 	})
 }

--- a/cronsetup/internal/cron/cron_test.go
+++ b/cronsetup/internal/cron/cron_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -345,6 +346,50 @@ func TestRunningMultipleSchedules(t *testing.T) {
 		t.FailNow()
 	case <-wait(wg):
 	}
+}
+
+func TestRunEntriesSkipsMissedOccurrences(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cron, err := New()
+		if err != nil {
+			t.Fatal("unexpected error")
+		}
+
+		run := make(chan struct{}, 1)
+		effective := time.Date(2026, time.August, 14, 6, 0, 0, 0, time.UTC)
+		now := effective.Add(time.Hour)
+		cron.entries = []*Entry{
+			{
+				Schedule: Every(time.Minute),
+				Next:     effective,
+				Job: Job{
+					Name: "test-skip-missed-occurrences",
+					Func: func(context.Context) error {
+						run <- struct{}{}
+						return nil
+					},
+				},
+			},
+		}
+
+		cron.runEntries(t.Context(), effective, now)
+		synctest.Wait()
+
+		select {
+		case <-run:
+		default:
+			t.Fatal("expected the due job to run")
+		}
+
+		entry := cron.entries[0]
+		if entry.Prev != effective {
+			t.Errorf("previous run = %s, want %s", entry.Prev, effective)
+		}
+		wantNext := now.Add(time.Minute)
+		if entry.Next != wantNext {
+			t.Errorf("next run = %s, want %s", entry.Next, wantNext)
+		}
+	})
 }
 
 // Test that the cron is run in the local time zone (as opposed to UTC).


### PR DESCRIPTION
After a pause, cronsetup advanced each entry from its stale scheduled time and replayed every missed slot.

Advance the next run from the timer delivery time instead. A due job runs once after resume, then its next run is scheduled after the current time. The etcd mutex still uses the original scheduled slot.

Closes #1646.

Tests:
- `go test -mod=mod ./...`
- `go test -mod=mod -race ./internal/cron -run '^TestRunEntriesSkipsMissedOccurrences$' -count=20`